### PR TITLE
Implement progress line for downloads using LuaSocket

### DIFF
--- a/src/luarocks/fs/lua.lua
+++ b/src/luarocks/fs/lua.lua
@@ -618,7 +618,7 @@ local function request(url, method, context)
       method = method,
       redirect = false,
       sink = ltn12.sink.table(result),
-      step = cfg.show_downloads and function(source, sink)
+      step = function(source, sink)
          local chunk, source_err = source()
          local ret, sink_err = sink(chunk, source_err)
 

--- a/test/testing.lua
+++ b/test/testing.lua
@@ -163,9 +163,6 @@ local tests = {
       return run '$luarocks build "$testing_dir/testfiles/invalid_patch-0.1-1.rockspec"'
    end,
    test_build_deps_partial_match = function() return run "$luarocks build lmathx" end,
-   test_build_show_downloads = function()
-      return run("$luarocks build alien", { LUAROCKS_CONFIG="$testing_dir/testing_config_show_downloads.lua" })
-   end,
    test_download_all = function()
       return run "$luarocks download --all validate-args"
          and rm(glob("validate-args-*"))

--- a/test/testing.sh
+++ b/test/testing.sh
@@ -59,7 +59,6 @@ rm -rf "$testing_sys_tree"
 rm -rf "$testing_tree_copy"
 rm -rf "$testing_sys_tree_copy"
 rm -rf "$testing_dir/testing_config.lua"
-rm -rf "$testing_dir/testing_config_show_downloads.lua"
 rm -rf "$testing_dir/testing_config_sftp.lua"
 rm -rf "$testing_dir/luacov.config"
 
@@ -99,10 +98,6 @@ external_deps_dirs = {
    }
 }
 EOF
-(
-   cat $testing_dir/testing_config.lua
-   echo "show_downloads = true"
-) > $testing_dir/testing_config_show_downloads.lua
 cat <<EOF > $testing_dir/testing_config_sftp.lua
 rocks_trees = {
    "$testing_tree",
@@ -401,7 +396,6 @@ fail_build_missing_external() { $luarocks build "$testing_dir/testfiles/missing_
 fail_build_invalidpatch() { need_luasocket; $luarocks build "$testing_dir/testfiles/invalid_patch-0.1-1.rockspec"; }
 
 test_build_deps_partial_match() { $luarocks build lmathx; }
-test_build_show_downloads() { export LUAROCKS_CONFIG="$testing_dir/testing_config_show_downloads.lua" && $luarocks build alien; export LUAROCKS_CONFIG="$testing_dir/testing_config.lua"; }
 
 test_download_all() { $luarocks download --all validate-args && rm validate-args-*; }
 test_download_rockspecversion() { $luarocks download --rockspec validate-args ${verrev_validate_args} && rm validate-args-*; }


### PR DESCRIPTION
It looks like this:

```
Downloading https://luarocks.org/luacheck-0.15.0-1.src.rock
  Got 1.03 MiB (100%) | 20.77 KiB/s
```

Current downloaded size, percentage and download speed are updated on each luasocket step. Redirections are handled. Progress line is shown only for sufficiently large files or slow downloads, thresholds may need some tweaking.

The last commit turns this on by default and removes any mentions of `cfg.show_downloads` from tests.
