### PR TITLE
[WIP] Add source.revision

### DIFF
--- a/spec/pack_spec.lua
+++ b/spec/pack_spec.lua
@@ -65,17 +65,23 @@ describe("LuaRocks pack tests #blackbox #b_pack", function()
       assert.is_false(run.luarocks_bool("pack "..rspec("revision_too_old")))
       assert.is_false(run.luarocks_bool("pack "..rspec("revision_too_short")))
       assert.is_false(run.luarocks_bool("pack "..rspec("revision_nonexistent_rev")))
+	  
+      -- broken
+      -- assert.is_false(run.luarocks_bool("pack "..rspec("revision_bad_url")))
 
       assert.is_true(run.luarocks_bool("pack "..rspec("revision_hg")))
       assert.is_true(run.luarocks_bool("pack "..rspec("revision_git")))
       assert.is_true(run.luarocks_bool("pack "..rspec("revision_shorthash")))
+
       assert.is_true(run.luarocks_bool("pack "..rspec("revision_branched")))
       assert.is_true(run.luarocks_bool("pack "..rspec("revision_tagged")))
+      assert.is_true(run.luarocks_bool("pack "..rspec("revision_tagged_and_branched")))
+
+      assert.is_false(run.luarocks_bool("pack "..rspec("revision_not_on_branch")))
+      assert.is_true(run.luarocks_bool("pack "..rspec("revision_beats_tag")))
 
       assert.is_true(test_env.remove_files(lfs.currentdir(), "revision_"))
 
-      -- broken
-      -- assert.is_false(run.luarocks_bool("pack "..rspec("revision_bad_url")))
    end)
 end)
 

--- a/spec/pack_spec.lua
+++ b/spec/pack_spec.lua
@@ -63,12 +63,16 @@ describe("LuaRocks pack tests #blackbox #b_pack", function()
       end
       assert.is_false(run.luarocks_bool("pack "..rspec("invalid_revision")))
       assert.is_false(run.luarocks_bool("pack "..rspec("revision_too_old")))
+      assert.is_false(run.luarocks_bool("pack "..rspec("revision_too_short")))
       assert.is_false(run.luarocks_bool("pack "..rspec("revision_nonexistent_rev")))
 
       assert.is_true(run.luarocks_bool("pack "..rspec("revision_hg")))
       assert.is_true(run.luarocks_bool("pack "..rspec("revision_git")))
+      assert.is_true(run.luarocks_bool("pack "..rspec("revision_shorthash")))
       assert.is_true(run.luarocks_bool("pack "..rspec("revision_branched")))
       assert.is_true(run.luarocks_bool("pack "..rspec("revision_tagged")))
+
+      assert.is_true(test_env.remove_files(lfs.currentdir(), "revision_"))
 
       -- broken
       -- assert.is_false(run.luarocks_bool("pack "..rspec("revision_bad_url")))

--- a/spec/pack_spec.lua
+++ b/spec/pack_spec.lua
@@ -58,13 +58,20 @@ describe("LuaRocks pack tests #blackbox #b_pack", function()
    end)
 
    it("LuaRocks pack scm revisions #623", function()
-	   local function rspec(name)
-		   return testing_paths.testing_dir  .. "/testfiles/" .. name .."-1.0-1.rockspec"
-	   end
-	   assert.is_false(run.luarocks_bool("pack "..rspec("invalid_revision")))
-	   assert.is_false(run.luarocks_bool("pack "..rspec("revision_too_old")))
-	   assert.is_false(run.luarocks_bool("pack "..rspec("revision_bad_url")))
-	   assert.is_false(run.luarocks_bool("pack "..rspec("revision_nonexistent_rev")))
+      local function rspec(name)
+          return testing_paths.testing_dir  .. "/testfiles/" .. name .."-1.0-1.rockspec"
+      end
+      assert.is_false(run.luarocks_bool("pack "..rspec("invalid_revision")))
+      assert.is_false(run.luarocks_bool("pack "..rspec("revision_too_old")))
+      assert.is_false(run.luarocks_bool("pack "..rspec("revision_nonexistent_rev")))
+
+      assert.is_true(run.luarocks_bool("pack "..rspec("revision_hg")))
+      assert.is_true(run.luarocks_bool("pack "..rspec("revision_git")))
+      assert.is_true(run.luarocks_bool("pack "..rspec("revision_branched")))
+      assert.is_true(run.luarocks_bool("pack "..rspec("revision_tagged")))
+
+      -- broken
+      -- assert.is_false(run.luarocks_bool("pack "..rspec("revision_bad_url")))
    end)
 end)
 

--- a/spec/pack_spec.lua
+++ b/spec/pack_spec.lua
@@ -56,6 +56,15 @@ describe("LuaRocks pack tests #blackbox #b_pack", function()
       assert.is_true(run.luarocks_bool("pack luasocket-3.0rc1-2.rockspec"))
       assert.is_true(test_env.remove_files(lfs.currentdir(), "luasocket-"))
    end)
-end)
 
+   it("LuaRocks pack scm revisions #623", function()
+	   local function rspec(name)
+		   return testing_paths.testing_dir  .. "/testfiles/" .. name .."-1.0-1.rockspec"
+	   end
+	   assert.is_false(run.luarocks_bool("pack "..rspec("invalid_revision")))
+	   assert.is_false(run.luarocks_bool("pack "..rspec("revision_too_old")))
+	   assert.is_false(run.luarocks_bool("pack "..rspec("revision_bad_url")))
+	   assert.is_false(run.luarocks_bool("pack "..rspec("revision_nonexistent_rev")))
+   end)
+end)
 

--- a/src/luarocks/core/type_check.lua
+++ b/src/luarocks/core/type_check.lua
@@ -117,7 +117,11 @@ local function type_check_item(version, item, typetbl, context)
       end
       if typetbl._pattern then
          if not item:match("^"..typetbl._pattern.."$") then
-            return nil, "Type mismatch on field "..context..": invalid value "..item.." does not match '"..typetbl._pattern.."'"
+            if typetbl._expecting then
+               return nil, "Type mismatch on field "..context..": invalid value "..item.." is not "..typetbl._expecting
+            else
+               return nil, "Type mismatch on field "..context..": invalid value "..item.." does not match '"..typetbl._pattern.."'"
+            end
          end
       end
    elseif expected_type == "table" then

--- a/src/luarocks/fetch.lua
+++ b/src/luarocks/fetch.lua
@@ -237,6 +237,10 @@ function fetch.load_local_rockspec(filename, quick)
    if rockspec.source.cvs_module then rockspec.source.module = rockspec.source.cvs_module end
    if rockspec.source.cvs_tag then rockspec.source.tag = rockspec.source.cvs_tag end
 
+   if rockspec.source.revision and not deps.format_is_at_least("3.0") then
+      return nil, "source.revision is only supported in rockspec format 3.0 or higher"
+   end
+
    local name_version = rockspec.package:lower() .. "-" .. rockspec.version
    if basename ~= "rockspec" and basename ~= name_version .. ".rockspec" then
       return nil, "Inconsistency between rockspec filename ("..basename..") and its contents ("..name_version..".rockspec)."

--- a/src/luarocks/fetch.lua
+++ b/src/luarocks/fetch.lua
@@ -237,10 +237,6 @@ function fetch.load_local_rockspec(filename, quick)
    if rockspec.source.cvs_module then rockspec.source.module = rockspec.source.cvs_module end
    if rockspec.source.cvs_tag then rockspec.source.tag = rockspec.source.cvs_tag end
 
-   if rockspec.source.revision and not deps.format_is_at_least("3.0") then
-      return nil, "source.revision is only supported in rockspec format 3.0 or higher"
-   end
-
    local name_version = rockspec.package:lower() .. "-" .. rockspec.version
    if basename ~= "rockspec" and basename ~= name_version .. ".rockspec" then
       return nil, "Inconsistency between rockspec filename ("..basename..") and its contents ("..name_version..".rockspec)."

--- a/src/luarocks/fetch/git_http.lua
+++ b/src/luarocks/fetch/git_http.lua
@@ -20,7 +20,7 @@ local git = require("luarocks.fetch.git")
 -- store it; or nil and an error message.
 function git_http.get_sources(rockspec, extract, dest_dir)
    rockspec.source.url = rockspec.source.url:gsub("^git.", "")
-   return git.get_sources(rockspec, extract, dest_dir, "--")
+   return git.get_sources(rockspec, extract, dest_dir)
 end
 
 return git_http

--- a/src/luarocks/fetch/git_ssh.lua
+++ b/src/luarocks/fetch/git_ssh.lua
@@ -26,7 +26,7 @@ function git_ssh.get_sources(rockspec, extract, dest_dir)
       rockspec.source.url = rockspec.source.url:gsub("^ssh://", "")
    end
 
-   return git.get_sources(rockspec, extract, dest_dir, "--")
+   return git.get_sources(rockspec, extract, dest_dir)
 end
 
 return git_ssh

--- a/src/luarocks/fetch/hg.lua
+++ b/src/luarocks/fetch/hg.lua
@@ -32,9 +32,15 @@ function hg.get_sources(rockspec, extract, dest_dir)
    local module = dir.base_name(url)
 
    local command = {hg_cmd, "clone", url, module}
-   local tag_or_branch = rockspec.source.tag or rockspec.source.branch
-   if tag_or_branch then
-      command = {hg_cmd, "clone", "--rev", tag_or_branch, url, module}
+
+   -- TODO: if revision is specified and so are tag/branch, then validate to
+   -- make sure tag/branch matches revision
+   local rev = rockspec.source.revision
+   rev = rev or rockspec.source.tag
+   rev = rev or rockspec.source.branch
+
+   if rev then
+      command = {hg_cmd, "clone", "--rev", rev, url, module}
    end
    local store_dir
    if not dest_dir then

--- a/src/luarocks/type_check.lua
+++ b/src/luarocks/type_check.lua
@@ -63,7 +63,7 @@ local rockspec_types = {
       dir = string_1,
       tag = string_1,
       branch = string_1,
-      revision = string_1,
+      revision = { _type = "string", _pattern = string.rep("%x",40), _version = "3.0" },
       module = string_1,
       cvs_tag = string_1,
       cvs_module = string_1,

--- a/src/luarocks/type_check.lua
+++ b/src/luarocks/type_check.lua
@@ -63,7 +63,12 @@ local rockspec_types = {
       dir = string_1,
       tag = string_1,
       branch = string_1,
-      revision = { _type = "string", _pattern = string.rep("%x",40), _version = "3.0" },
+	  revision = {
+		  _type = "string",
+		  _version = "3.0",
+		  _pattern = "%x%x%x%x+",
+		  _expecting = "a hexadecimal string of at least 4 characters"
+	  },
       module = string_1,
       cvs_tag = string_1,
       cvs_module = string_1,

--- a/src/luarocks/type_check.lua
+++ b/src/luarocks/type_check.lua
@@ -63,6 +63,7 @@ local rockspec_types = {
       dir = string_1,
       tag = string_1,
       branch = string_1,
+      revision = string_1,
       module = string_1,
       cvs_tag = string_1,
       cvs_module = string_1,

--- a/src/luarocks/type_check.lua
+++ b/src/luarocks/type_check.lua
@@ -63,12 +63,12 @@ local rockspec_types = {
       dir = string_1,
       tag = string_1,
       branch = string_1,
-	  revision = {
-		  _type = "string",
-		  _version = "3.0",
-		  _pattern = "%x%x%x%x+",
-		  _expecting = "a hexadecimal string of at least 4 characters"
-	  },
+      revision = {
+         _type      = "string",
+         _version   = "3.0",
+         _pattern   = "%x%x%x%x+",
+         _expecting = "a hexadecimal string of at least 4 characters"
+      },
       module = string_1,
       cvs_tag = string_1,
       cvs_module = string_1,

--- a/test/testfiles/invalid_revision-1.0-1.rockspec
+++ b/test/testfiles/invalid_revision-1.0-1.rockspec
@@ -1,0 +1,9 @@
+rockspec_format="3.0"
+package="invalid_revision"
+version="1.0-1"
+source = {
+	url = "git://github.com/keplerproject/luarocks",
+	revision = "HEAD"
+}
+build = {type="none"}
+

--- a/test/testfiles/revision_bad_url-1.0-1.rockspec
+++ b/test/testfiles/revision_bad_url-1.0-1.rockspec
@@ -1,0 +1,9 @@
+rockspec_format="3.0"
+package="revision_bad_url"
+source = {
+	url = "http://example.com",
+	revision = "0000000000000000000000000000000000000000"
+}
+version="1.0-1"
+build={type="none"}
+

--- a/test/testfiles/revision_beats_tag-1.0-1.rockspec
+++ b/test/testfiles/revision_beats_tag-1.0-1.rockspec
@@ -1,10 +1,12 @@
 rockspec_format = "3.0"
-package = "revision_branched"
+package = "revision_beats_tag"
 version = "1.0-1"
+-- To be consistent with how tags beat branches, revisions should beat tags.
 source = {
    url = "git://github.com/Alloyed/git_test",
-   branch = "mybranch",
-   revision = "01673c6ed890224490452d79e36fc36cdd460960"
+   tag = "#2",
+   -- change #1 on master
+   revision = "4d1e421287df69fad1338a45591c27116c6736ab"
 }
 description = {
    homepage = "https://github.com/Alloyed/git_test",

--- a/test/testfiles/revision_branched-1.0-1.rockspec
+++ b/test/testfiles/revision_branched-1.0-1.rockspec
@@ -1,0 +1,16 @@
+rockspec_format = "3.0"
+package = "revision_branched"
+version = "1.0-1"
+source = {
+   url = "git://github.com/Alloyed/git_test",
+   branch = "mybranch",
+   revision = "e97925b86a15227ddd4c232dc62db683f7ee1c3c"
+}
+description = {
+   homepage = "https://github.com/Alloyed/git_test",
+}
+dependencies = {}
+build = {
+   type = "builtin",
+   modules = {}
+}

--- a/test/testfiles/revision_git-1.0-1.rockspec
+++ b/test/testfiles/revision_git-1.0-1.rockspec
@@ -1,0 +1,15 @@
+rockspec_format = "3.0"
+package = "revision_git"
+version = "1.0-1"
+source = {
+   url = "git://github.com/Alloyed/git_test",
+   revision = "1618ff04fad379d9d9757ece9567fb73b5bc8104"
+}
+description = {
+   homepage = "https://github.com/Alloyed/git_test",
+}
+dependencies = {}
+build = {
+   type = "builtin",
+   modules = {}
+}

--- a/test/testfiles/revision_hg-1.0-1.rockspec
+++ b/test/testfiles/revision_hg-1.0-1.rockspec
@@ -1,0 +1,14 @@
+rockspec_format = "3.0"
+package = "revision_hg"
+version = "1.0-1"
+source = {
+   url = "hg+https://bitbucket.org/Alloyed/hg_test",
+   revision = "00f023135ad6494755dcb92113956cf1f1df2a88",
+}
+description = {
+}
+dependencies = {}
+build = {
+   type = "builtin",
+   modules = {}
+}

--- a/test/testfiles/revision_nonexistent_rev-1.0-1.rockspec
+++ b/test/testfiles/revision_nonexistent_rev-1.0-1.rockspec
@@ -1,0 +1,9 @@
+rockspec_format = "3.0"
+package="revision_nonexistent_rev"
+source = {
+	url = "git://github.com/keplerproject/luarocks",
+	revision = "0000000000000000000000000000000000000000"
+}
+version="1.0-1"
+build={type="none"}
+

--- a/test/testfiles/revision_nonexistent_rev-1.0-1.rockspec
+++ b/test/testfiles/revision_nonexistent_rev-1.0-1.rockspec
@@ -1,7 +1,7 @@
 rockspec_format = "3.0"
 package="revision_nonexistent_rev"
 source = {
-	url = "git://github.com/keplerproject/luarocks",
+	url = "git://github.com/alloyed/git_test",
 	revision = "0000000000000000000000000000000000000000"
 }
 version="1.0-1"

--- a/test/testfiles/revision_not_on_branch-1.0-1.rockspec
+++ b/test/testfiles/revision_not_on_branch-1.0-1.rockspec
@@ -1,10 +1,11 @@
 rockspec_format = "3.0"
-package = "revision_branched"
+package = "revision_not_on_branch"
 version = "1.0-1"
 source = {
    url = "git://github.com/Alloyed/git_test",
    branch = "mybranch",
-   revision = "01673c6ed890224490452d79e36fc36cdd460960"
+   -- change #3 on master
+   revision = "56bc5ec9dc03e3f05cfa39b292e116b07d44c90e"
 }
 description = {
    homepage = "https://github.com/Alloyed/git_test",

--- a/test/testfiles/revision_shorthash-1.0-1.rockspec
+++ b/test/testfiles/revision_shorthash-1.0-1.rockspec
@@ -1,0 +1,15 @@
+rockspec_format = "3.0"
+package = "revision_shorthash"
+version = "1.0-1"
+source = {
+   url = "git://github.com/Alloyed/git_test",
+   revision = "1618ff"
+}
+description = {
+   homepage = "https://github.com/Alloyed/git_test",
+}
+dependencies = {}
+build = {
+   type = "builtin",
+   modules = {}
+}

--- a/test/testfiles/revision_tagged-1.0-1.rockspec
+++ b/test/testfiles/revision_tagged-1.0-1.rockspec
@@ -1,0 +1,16 @@
+rockspec_format = "3.0"
+package = "revision_tagged"
+version = "1.0-1"
+source = {
+   url = "git://github.com/Alloyed/git_test",
+   tag = "#2",
+   revision = "1618ff04fad379d9d9757ece9567fb73b5bc8104"
+}
+description = {
+   homepage = "https://github.com/Alloyed/git_test",
+}
+dependencies = {}
+build = {
+   type = "builtin",
+   modules = {}
+}

--- a/test/testfiles/revision_tagged_and_branched-1.0-1.rockspec
+++ b/test/testfiles/revision_tagged_and_branched-1.0-1.rockspec
@@ -1,10 +1,11 @@
 rockspec_format = "3.0"
-package = "revision_branched"
+package = "revision_tagged_and_branched"
 version = "1.0-1"
 source = {
    url = "git://github.com/Alloyed/git_test",
    branch = "mybranch",
-   revision = "01673c6ed890224490452d79e36fc36cdd460960"
+   tag = "#mybranch.2",
+   revision = "e97925b86a15227ddd4c232dc62db683f7ee1c3c"
 }
 description = {
    homepage = "https://github.com/Alloyed/git_test",

--- a/test/testfiles/revision_too_old-1.0-1.rockspec
+++ b/test/testfiles/revision_too_old-1.0-1.rockspec
@@ -1,0 +1,8 @@
+package="revision_too_old"
+source = {
+	url = "git://doesnot.matter",
+	revision = "0000000000000000000000000000000000000000"
+}
+version="1.0-1"
+build={type="none"}
+

--- a/test/testfiles/revision_too_short-1.0-1.rockspec
+++ b/test/testfiles/revision_too_short-1.0-1.rockspec
@@ -1,0 +1,15 @@
+rockspec_format = "3.0"
+package = "revision_too_short"
+version = "1.0-1"
+source = {
+   url = "git://github.com/Alloyed/git_test",
+   revision = "161"
+}
+description = {
+   homepage = "https://github.com/Alloyed/git_test",
+}
+dependencies = {}
+build = {
+   type = "builtin",
+   modules = {}
+}


### PR DESCRIPTION
Resolves #569.

In hg, this is implemented by passing revision into the clone command (`hg clone myrepo --rev myrev`).

In git, this is implemented by performing a full clone (`git clone myrepo`) and then doing `git checkout myrev`.

Originally I planned to have a special case that compares `source.tag` and `source.revision` when both are defined. This would double check the tag's commit-id, but from a security perspective that just moves the trust from the repository host to the rockspec host. Git already supports tag/commit signing with GPG, which are better ways to verify trust.

todo:
- [x] input validation (revisions should _only_ be full commit/changeset IDs)
- [x] git optimizations

tests:
- [x] error on revision in rockspec < 3.0
- [ ] error on revision in unsupported URL type (other schemes don't do this it looks like)
- [x] simple revision in git
- [x] simple revision in hg
- [x] revision + tag
- [x] revision + branch (with `--single-branch` this can be special-cased to avoid full clone)
- [x] revision + tag + branch
