### PR TITLE
Split out luarocks.vers from luarocks.deps

### DIFF
--- a/Makefile.setup.inc
+++ b/Makefile.setup.inc
@@ -21,4 +21,4 @@ admin/cmd/make_manifest.lua admin/cmd/add.lua admin/cmd/remove.lua \
 admin/cmd/refresh_cache.lua remove.lua fetch/git_file.lua fetch/sscm.lua \
 fetch/cvs.lua fetch/git_https.lua fetch/git_ssh.lua fetch/hg_http.lua \
 fetch/git_http.lua fetch/svn.lua fetch/git.lua fetch/hg_ssh.lua \
-fetch/hg_https.lua fetch/hg.lua
+fetch/hg_https.lua fetch/hg.lua vers.lua core/vers.lua

--- a/src/luarocks/cmd/list.lua
+++ b/src/luarocks/cmd/list.lua
@@ -4,7 +4,7 @@
 local list = {}
 
 local search = require("luarocks.search")
-local deps = require("luarocks.deps")
+local vers = require("luarocks.vers")
 local cfg = require("luarocks.core.cfg")
 local util = require("luarocks.util")
 local path = require("luarocks.path")
@@ -28,7 +28,7 @@ local function check_outdated(trees, query)
    local outdated = {}
    for name, versions in util.sortedpairs(results_installed) do
       versions = util.keys(versions)
-      table.sort(versions, deps.compare_versions)
+      table.sort(versions, vers.compare_versions)
       local latest_installed = versions[1]
 
       local query_available = search.make_query(name:lower())
@@ -37,11 +37,11 @@ local function check_outdated(trees, query)
       
       if results_available[name] then
          local available_versions = util.keys(results_available[name])
-         table.sort(available_versions, deps.compare_versions)
+         table.sort(available_versions, vers.compare_versions)
          local latest_available = available_versions[1]
          local latest_available_repo = results_available[name][latest_available][1].repo
          
-         if deps.compare_versions(latest_available, latest_installed) then
+         if vers.compare_versions(latest_available, latest_installed) then
             table.insert(outdated, { name = name, installed = latest_installed, available = latest_available, repo = latest_available_repo })
          end
       end

--- a/src/luarocks/cmd/purge.lua
+++ b/src/luarocks/cmd/purge.lua
@@ -7,7 +7,7 @@ local util = require("luarocks.util")
 local fs = require("luarocks.fs")
 local path = require("luarocks.path")
 local search = require("luarocks.search")
-local deps = require("luarocks.deps")
+local vers = require("luarocks.vers")
 local repos = require("luarocks.repos")
 local writer = require("luarocks.manif.writer")
 local cfg = require("luarocks.core.cfg")
@@ -48,9 +48,9 @@ function purge.command(flags)
 
    search.manifest_search(results, path.rocks_dir(tree), query)
 
-   local sort = function(a,b) return deps.compare_versions(b,a) end
+   local sort = function(a,b) return vers.compare_versions(b,a) end
    if flags["old-versions"] then
-      sort = deps.compare_versions
+      sort = vers.compare_versions
    end
 
    for package, versions in util.sortedpairs(results) do

--- a/src/luarocks/cmd/show.lua
+++ b/src/luarocks/cmd/show.lua
@@ -6,7 +6,7 @@ local search = require("luarocks.search")
 local cfg = require("luarocks.core.cfg")
 local util = require("luarocks.util")
 local path = require("luarocks.path")
-local deps = require("luarocks.deps")
+local vers = require("luarocks.vers")
 local fetch = require("luarocks.fetch")
 local manif = require("luarocks.manif")
 local repos = require("luarocks.repos")
@@ -147,7 +147,7 @@ function show.command(flags, name, version)
          util.printout("Depends on:")
          for _, dep in ipairs(rockspec.dependencies) do
             direct_deps[dep.name] = true
-            util.printout("\t"..deps.show_dep(dep).." "..installed_rock_label(dep.name, flags["tree"]))
+            util.printout("\t"..vers.show_dep(dep).." "..installed_rock_label(dep.name, flags["tree"]))
          end
       end
       local has_indirect_deps

--- a/src/luarocks/cmd/write_rockspec.lua
+++ b/src/luarocks/cmd/write_rockspec.lua
@@ -9,7 +9,7 @@ local path = require("luarocks.path")
 local persist = require("luarocks.persist")
 local type_check = require("luarocks.type_check")
 local util = require("luarocks.util")
-local deps = require("luarocks.deps")
+local vers = require("luarocks.vers")
 
 write_rockspec.help_summary = "Write a template for a rockspec file."
 write_rockspec.help_arguments = "[--output=<file> ...] [<name>] [<version>] [<url>|<path>]"
@@ -285,7 +285,7 @@ function write_rockspec.command(flags, name, version, url_or_dir)
    }
    path.configure_paths(rockspec)
    rockspec.source.protocol = protocol
-   rockspec.format_is_at_least = deps.format_is_at_least
+   rockspec.format_is_at_least = vers.format_is_at_least
    
    configure_lua_version(rockspec, flags["lua-version"])
    

--- a/src/luarocks/core/type_check.lua
+++ b/src/luarocks/core/type_check.lua
@@ -2,7 +2,7 @@
 local type_check = {}
 
 local cfg = require("luarocks.core.cfg")
-local deps = require("luarocks.core.deps")
+local vers = require("luarocks.core.vers")
 local require = nil
 --------------------------------------------------------------------------------
 
@@ -74,7 +74,7 @@ local manifest_types = {
 
 local function check_version(version, typetbl, context)
    local typetbl_version = typetbl._version or "1.0"
-   if deps.compare_versions(typetbl_version, version) then
+   if vers.compare_versions(typetbl_version, version) then
       if context == "" then
          return nil, "Invalid rockspec_format version number in rockspec? Please fix rockspec accordingly."
       else

--- a/src/luarocks/core/vers.lua
+++ b/src/luarocks/core/vers.lua
@@ -1,5 +1,5 @@
 
-local deps = {}
+local vers = {}
 
 local util = require("luarocks.core.util")
 local require = nil
@@ -73,7 +73,7 @@ setmetatable(version_cache, {
 -- @param vstring string: A version number in string format.
 -- @return table or nil: A version table or nil
 -- if the input string contains invalid characters.
-function deps.parse_version(vstring)
+function vers.parse_version(vstring)
    if not vstring then return nil end
    assert(type(vstring) == "string")
 
@@ -125,8 +125,8 @@ end
 -- @param a string: one version.
 -- @param b string: another version.
 -- @return boolean: True if a > b.
-function deps.compare_versions(a, b)
-   return deps.parse_version(a) > deps.parse_version(b)
+function vers.compare_versions(a, b)
+   return vers.parse_version(a) > vers.parse_version(b)
 end
 
 --- A more lenient check for equivalence between versions.
@@ -145,8 +145,8 @@ local function partial_match(version, requested)
    assert(type(version) == "string" or type(version) == "table")
    assert(type(requested) == "string" or type(version) == "table")
 
-   if type(version) ~= "table" then version = deps.parse_version(version) end
-   if type(requested) ~= "table" then requested = deps.parse_version(requested) end
+   if type(version) ~= "table" then version = vers.parse_version(version) end
+   if type(requested) ~= "table" then requested = vers.parse_version(requested) end
    if not version or not requested then return false end
    
    for i, ri in ipairs(requested) do
@@ -164,14 +164,14 @@ end
 -- @param constraints table: An array of constraints in table format.
 -- @return boolean: True if version satisfies all constraints,
 -- false otherwise.
-function deps.match_constraints(version, constraints)
+function vers.match_constraints(version, constraints)
    assert(type(version) == "table")
    assert(type(constraints) == "table")
    local ok = true
    setmetatable(version, version_mt)
    for _, constr in pairs(constraints) do
       if type(constr.version) == "string" then
-         constr.version = deps.parse_version(constr.version)
+         constr.version = vers.parse_version(constr.version)
       end
       local constr_version, constr_op = constr.version, constr.op
       setmetatable(constr_version, version_mt)
@@ -188,5 +188,4 @@ function deps.match_constraints(version, constraints)
    return ok
 end
 
-return deps
-
+return vers

--- a/src/luarocks/deps.lua
+++ b/src/luarocks/deps.lua
@@ -1,147 +1,13 @@
 
---- Dependency handling functions.
--- Dependencies are represented in LuaRocks through strings with
--- a package name followed by a comma-separated list of constraints.
--- Each constraint consists of an operator and a version number.
--- In this string format, version numbers are represented as
--- naturally as possible, like they are used by upstream projects
--- (e.g. "2.0beta3"). Internally, LuaRocks converts them to a purely
--- numeric representation, allowing comparison following some
--- "common sense" heuristics. The precise specification of the
--- comparison criteria is the source code of this module, but the
--- test/test_deps.lua file included with LuaRocks provides some
--- insights on what these criteria are.
+--- High-level dependency related functions.
 local deps = {}
-setmetatable(deps, { __index = require("luarocks.core.deps") })
 
 local cfg = require("luarocks.core.cfg")
 local manif = require("luarocks.core.manif")
 local path = require("luarocks.path")
 local dir = require("luarocks.dir")
 local util = require("luarocks.util")
-
---- Check if rockspec format version satisfies version requirement.
--- @param rockspec table: The rockspec table.
--- @param version string: required version.
--- @return boolean: true if rockspec format matches version or is newer, false otherwise.
-function deps.format_is_at_least(rockspec, version)
-   local rockspec_format = rockspec.rockspec_format or "1.0"
-   return deps.parse_version(rockspec_format) >= deps.parse_version(version)
-end
-
-local operators = {
-   ["=="] = "==",
-   ["~="] = "~=",
-   [">"] = ">",
-   ["<"] = "<",
-   [">="] = ">=",
-   ["<="] = "<=",
-   ["~>"] = "~>",
-   -- plus some convenience translations
-   [""] = "==",
-   ["="] = "==",
-   ["!="] = "~="
-}
-
---- Consumes a constraint from a string, converting it to table format.
--- For example, a string ">= 1.0, > 2.0" is converted to a table in the
--- format {op = ">=", version={1,0}} and the rest, "> 2.0", is returned
--- back to the caller.
--- @param input string: A list of constraints in string format.
--- @return (table, string) or nil: A table representing the same
--- constraints and the string with the unused input, or nil if the
--- input string is invalid.
-local function parse_constraint(input)
-   assert(type(input) == "string")
-
-   local no_upgrade, op, version, rest = input:match("^(@?)([<>=~!]*)%s*([%w%.%_%-]+)[%s,]*(.*)")
-   local _op = operators[op]
-   version = deps.parse_version(version)
-   if not _op then
-      return nil, "Encountered bad constraint operator: '"..tostring(op).."' in '"..input.."'"
-   end
-   if not version then 
-      return nil, "Could not parse version from constraint: '"..input.."'"
-   end
-   return { op = _op, version = version, no_upgrade = no_upgrade=="@" and true or nil }, rest
-end
-
---- Convert a list of constraints from string to table format.
--- For example, a string ">= 1.0, < 2.0" is converted to a table in the format
--- {{op = ">=", version={1,0}}, {op = "<", version={2,0}}}.
--- Version tables use a metatable allowing later comparison through
--- relational operators.
--- @param input string: A list of constraints in string format.
--- @return table or nil: A table representing the same constraints,
--- or nil if the input string is invalid.
-function deps.parse_constraints(input)
-   assert(type(input) == "string")
-
-   local constraints, oinput, constraint = {}, input
-   while #input > 0 do
-      constraint, input = parse_constraint(input)
-      if constraint then
-         table.insert(constraints, constraint)
-      else
-         return nil, "Failed to parse constraint '"..tostring(oinput).."' with error: ".. input
-      end
-   end
-   return constraints
-end
-
---- Convert a dependency from string to table format.
--- For example, a string "foo >= 1.0, < 2.0"
--- is converted to a table in the format
--- {name = "foo", constraints = {{op = ">=", version={1,0}},
--- {op = "<", version={2,0}}}}. Version tables use a metatable
--- allowing later comparison through relational operators.
--- @param dep string: A dependency in string format
--- as entered in rockspec files.
--- @return table or nil: A table representing the same dependency relation,
--- or nil if the input string is invalid.
-function deps.parse_dep(dep)
-   assert(type(dep) == "string")
-
-   local name, rest = dep:match("^%s*([a-zA-Z0-9][a-zA-Z0-9%.%-%_]*)%s*(.*)")
-   if not name then return nil, "failed to extract dependency name from '"..tostring(dep).."'" end
-   local constraints, err = deps.parse_constraints(rest)
-   if not constraints then return nil, err end
-   return { name = name, constraints = constraints }
-end
-
---- Convert a version table to a string.
--- @param v table: The version table
--- @param internal boolean or nil: Whether to display versions in their
--- internal representation format or how they were specified.
--- @return string: The dependency information pretty-printed as a string.
-function deps.show_version(v, internal)
-   assert(type(v) == "table")
-   assert(type(internal) == "boolean" or not internal)
-
-   return (internal
-           and table.concat(v, ":")..(v.revision and tostring(v.revision) or "")
-           or v.string)
-end
-
---- Convert a dependency in table format to a string.
--- @param dep table: The dependency in table format
--- @param internal boolean or nil: Whether to display versions in their
--- internal representation format or how they were specified.
--- @return string: The dependency information pretty-printed as a string.
-function deps.show_dep(dep, internal)
-   assert(type(dep) == "table")
-   assert(type(internal) == "boolean" or not internal)
-
-   if #dep.constraints > 0 then
-      local pretty = {}
-      for _, c in ipairs(dep.constraints) do
-         table.insert(pretty, c.op .. " " .. deps.show_version(c.version, internal))
-      end
-      return dep.name.." "..table.concat(pretty, ", ")
-   else
-      return dep.name
-   end
-end
+local vers = require("luarocks.vers")
 
 --- Attempt to match a dependency to an installed rock.
 -- @param dep table: A dependency parsed in table format.
@@ -167,8 +33,8 @@ local function match_dep(dep, blacklist, deps_mode, rocks_provided)
    local latest_version
    for _, vstring in ipairs(versions) do
       if not blacklist or not blacklist[vstring] then
-         local version = deps.parse_version(vstring)
-         if deps.match_constraints(version, dep.constraints) then
+         local version = vers.parse_version(vstring)
+         if vers.match_constraints(version, dep.constraints) then
             if not latest_version or version > latest_version then
                latest_version = version
             end
@@ -249,7 +115,7 @@ function deps.report_missing_dependencies(name, version, dependencies, deps_mode
             first_missing_dep = false
          end
 
-         util.printout(("   %s (%s)"):format(deps.show_dep(dep), rock_status(dep.name, deps_mode, rocks_provided)))
+         util.printout(("   %s (%s)"):format(vers.show_dep(dep), rock_status(dep.name, deps_mode, rocks_provided)))
       end
    end
 end
@@ -306,11 +172,11 @@ function deps.fulfill_dependencies(rockspec, deps_mode)
          end
 
          util.printout(("%s %s depends on %s (%s)"):format(
-            rockspec.name, rockspec.version, deps.show_dep(dep), rock_status(dep.name, deps_mode, rockspec.rocks_provided)))
+            rockspec.name, rockspec.version, vers.show_dep(dep), rock_status(dep.name, deps_mode, rockspec.rocks_provided)))
 
          if dep.constraints[1] and dep.constraints[1].no_upgrade then
             util.printerr("This version of "..rockspec.name.." is designed for use with")
-            util.printerr(deps.show_dep(dep)..", but is configured to avoid upgrading it")
+            util.printerr(vers.show_dep(dep)..", but is configured to avoid upgrading it")
             util.printerr("automatically. Please upgrade "..dep.name.." with")
             util.printerr("   luarocks install "..dep.name)
             util.printerr("or choose an older version of "..rockspec.name.." with")
@@ -320,7 +186,7 @@ function deps.fulfill_dependencies(rockspec, deps_mode)
 
          local url, search_err = search.find_suitable_rock(dep)
          if not url then
-            return nil, "Could not satisfy dependency "..deps.show_dep(dep)..": "..search_err
+            return nil, "Could not satisfy dependency "..vers.show_dep(dep)..": "..search_err
          end
          util.printout("Installing "..url)
          local ok, install_err, errcode = install.command({deps_mode = deps_mode}, url)

--- a/src/luarocks/deps.lua
+++ b/src/luarocks/deps.lua
@@ -3,7 +3,7 @@
 local deps = {}
 
 local cfg = require("luarocks.core.cfg")
-local manif = require("luarocks.core.manif")
+local manif = require("luarocks.manif")
 local path = require("luarocks.path")
 local dir = require("luarocks.dir")
 local util = require("luarocks.util")

--- a/src/luarocks/fetch.lua
+++ b/src/luarocks/fetch.lua
@@ -6,7 +6,7 @@ local fs = require("luarocks.fs")
 local dir = require("luarocks.dir")
 local type_check = require("luarocks.type_check")
 local path = require("luarocks.path")
-local deps = require("luarocks.deps")
+local vers = require("luarocks.vers")
 local persist = require("luarocks.persist")
 local util = require("luarocks.util")
 local cfg = require("luarocks.core.cfg")
@@ -197,7 +197,7 @@ function fetch.load_local_rockspec(filename, quick)
    local globals = err
 
    if rockspec.rockspec_format then
-      if deps.compare_versions(rockspec.rockspec_format, type_check.rockspec_format) then
+      if vers.compare_versions(rockspec.rockspec_format, type_check.rockspec_format) then
          return nil, "Rockspec format "..rockspec.rockspec_format.." is not supported, please upgrade LuaRocks."
       end
    end
@@ -209,7 +209,7 @@ function fetch.load_local_rockspec(filename, quick)
       end
    end
    
-   rockspec.format_is_at_least = deps.format_is_at_least
+   rockspec.format_is_at_least = vers.format_is_at_least
 
    util.platform_overrides(rockspec.build)
    util.platform_overrides(rockspec.dependencies)
@@ -260,7 +260,7 @@ function fetch.load_local_rockspec(filename, quick)
 
    if rockspec.dependencies then
       for i = 1, #rockspec.dependencies do
-         local parsed, err = deps.parse_dep(rockspec.dependencies[i])
+         local parsed, err = vers.parse_dep(rockspec.dependencies[i])
          if not parsed then
             return nil, "Parse error processing dependency '"..rockspec.dependencies[i].."': "..tostring(err)
          end

--- a/src/luarocks/fetch/git.lua
+++ b/src/luarocks/fetch/git.lua
@@ -6,19 +6,19 @@ local unpack = unpack or table.unpack
 
 local fs = require("luarocks.fs")
 local dir = require("luarocks.dir")
-local deps = require("luarocks.deps")
+local vers = require("luarocks.vers")
 local util = require("luarocks.util")
 
 local cached_git_version
 
 --- Get git version.
 -- @param git_cmd string: name of git command.
--- @return table: git version as returned by luarocks.deps.parse_version.
+-- @return table: git version as returned by luarocks.vers.parse_version.
 local function git_version(git_cmd)
    if not cached_git_version then
       local version_line = io.popen(fs.Q(git_cmd)..' --version'):read()
       local version_string = version_line:match('%d-%.%d+%.?%d*')
-      cached_git_version = deps.parse_version(version_string)
+      cached_git_version = vers.parse_version(version_string)
    end
 
    return cached_git_version
@@ -29,7 +29,7 @@ end
 -- @param version string: required version.
 -- @return boolean: true if git matches version or is newer, false otherwise.
 local function git_is_at_least(git_cmd, version)
-   return git_version(git_cmd) >= deps.parse_version(version)
+   return git_version(git_cmd) >= vers.parse_version(version)
 end
 
 --- Git >= 1.7.10 can clone a branch **or tag**, < 1.7.10 by branch only. We

--- a/src/luarocks/index.lua
+++ b/src/luarocks/index.lua
@@ -4,7 +4,7 @@ local index = {}
 
 local util = require("luarocks.util")
 local fs = require("luarocks.fs")
-local deps = require("luarocks.deps")
+local vers = require("luarocks.vers")
 local persist = require("luarocks.persist")
 local dir = require("luarocks.dir")
 local manif = require("luarocks.manif")
@@ -134,7 +134,7 @@ function index.make_index(repo)
    for package, version_list in util.sortedpairs(manifest.repository) do
       local latest_rockspec = nil
       local output = index_package_begin
-      for version, data in util.sortedpairs(version_list, deps.compare_versions) do
+      for version, data in util.sortedpairs(version_list, vers.compare_versions) do
          local versions = {}
          output = output..version..':&nbsp;'
          table.sort(data, function(a,b) return a.arch < b.arch end)

--- a/src/luarocks/loader.lua
+++ b/src/luarocks/loader.lua
@@ -20,7 +20,7 @@ cfg.init_package_paths()
 
 local path = require("luarocks.core.path")
 local manif = require("luarocks.core.manif")
-local deps = require("luarocks.core.deps")
+local vers = require("luarocks.core.vers")
 local util = require("luarocks.core.util")
 local require = nil
 --------------------------------------------------------------------------------
@@ -112,8 +112,8 @@ function loader.add_context(name, version)
          for _, tree in ipairs(loader.rocks_trees) do
             local entries = tree.manifest.repository[pkg]
             if entries then
-               for version, pkgs in util.sortedpairs(entries, deps.compare_versions) do
-                  if (not constraints) or deps.match_constraints(deps.parse_version(version), constraints) then
+               for version, pkgs in util.sortedpairs(entries, vers.compare_versions) do
+                  if (not constraints) or vers.match_constraints(vers.parse_version(version), constraints) then
                      loader.add_context(pkg, version)
                   end
                end
@@ -190,7 +190,7 @@ local function select_module(module, filter_file_name)
             if loader.context[name] == version then
                return name, version, file_name
             end
-            version = deps.parse_version(version)
+            version = vers.parse_version(version)
             table.insert(providers, {name = name, version = version, module_name = file_name, tree = tree})
          end
       end

--- a/src/luarocks/manif/writer.lua
+++ b/src/luarocks/manif/writer.lua
@@ -5,6 +5,7 @@ local cfg = require("luarocks.core.cfg")
 local search = require("luarocks.search")
 local repos = require("luarocks.repos")
 local deps = require("luarocks.deps")
+local vers = require("luarocks.vers")
 local fs = require("luarocks.fs")
 local util = require("luarocks.util")
 local dir = require("luarocks.dir")
@@ -109,7 +110,7 @@ local function sort_pkgs(a, b)
    local na, va = a:match("(.*)/(.*)$")
    local nb, vb = b:match("(.*)/(.*)$")
 
-   return (na == nb) and deps.compare_versions(va, vb) or na < nb
+   return (na == nb) and vers.compare_versions(va, vb) or na < nb
 end
 
 --- Sort items of a package matching table by version number (higher versions first).
@@ -151,7 +152,7 @@ local function filter_by_lua_version(manifest, lua_version, repodir, cache)
    assert((not cache) or type(cache) == "table")
    
    cache = cache or {}
-   lua_version = deps.parse_version(lua_version)
+   lua_version = vers.parse_version(lua_version)
    for pkg, versions in pairs(manifest.repository) do
       local to_remove = {}
       for version, repositories in pairs(versions) do
@@ -166,7 +167,7 @@ local function filter_by_lua_version(manifest, lua_version, repodir, cache)
                   cache[pathname] = rockspec
                   for _, dep in ipairs(rockspec.dependencies) do
                      if dep.name == "lua" then 
-                        if not deps.match_constraints(lua_version, dep.constraints) then
+                        if not vers.match_constraints(lua_version, dep.constraints) then
                            table.insert(to_remove, version)
                         end
                         break
@@ -423,7 +424,7 @@ function writer.check_dependencies(repo, deps_mode)
    end
 
    for name, versions in util.sortedpairs(manifest.repository) do
-      for version, version_entries in util.sortedpairs(versions, deps.compare_versions) do
+      for version, version_entries in util.sortedpairs(versions, vers.compare_versions) do
          for _, entry in ipairs(version_entries) do
             if entry.arch == "installed" then
                if manifest.dependencies[name] and manifest.dependencies[name][version] then

--- a/src/luarocks/repos.lua
+++ b/src/luarocks/repos.lua
@@ -8,7 +8,7 @@ local cfg = require("luarocks.core.cfg")
 local util = require("luarocks.util")
 local dir = require("luarocks.dir")
 local manif = require("luarocks.manif")
-local deps = require("luarocks.deps")
+local vers = require("luarocks.vers")
 
 -- Tree of files installed by a package are stored
 -- in its rock manifest. Some of these files have to
@@ -246,7 +246,7 @@ local function prepare_target(name, version, deploy_type, file_path, suffix)
 
    if not cur_name then
       return non_versioned
-   elseif name < cur_name or (name == cur_name and deps.compare_versions(version, cur_version)) then
+   elseif name < cur_name or (name == cur_name and vers.compare_versions(version, cur_version)) then
       -- New version has priority. Move currently provided version back using versioned name.
       local cur_deploy_type, cur_file_path = manif.get_providing_file(cur_name, cur_version, item_type, item_name)
       local cur_non_versioned, cur_versioned = get_deploy_paths(cur_name, cur_version, cur_deploy_type, cur_file_path)

--- a/src/luarocks/search.lua
+++ b/src/luarocks/search.lua
@@ -3,7 +3,7 @@ local search = {}
 local dir = require("luarocks.dir")
 local path = require("luarocks.path")
 local manif = require("luarocks.manif")
-local deps = require("luarocks.deps")
+local vers = require("luarocks.vers")
 local cfg = require("luarocks.core.cfg")
 local util = require("luarocks.util")
 
@@ -92,7 +92,7 @@ end
 local function store_if_match(results, repo, name, version, arch, query)
    if match_name(query, name) then
       if query.arch[arch] or query.arch["any"] then
-         if deps.match_constraints(deps.parse_version(version), query.constraints) then
+         if vers.match_constraints(vers.parse_version(version), query.constraints) then
             search.store_result(results, name, version, arch, repo)
          end
       end
@@ -229,7 +229,7 @@ function search.make_query(name, version)
       constraints = {}
    }
    if version then
-      table.insert(query.constraints, { op = "==", version = deps.parse_version(version)})
+      table.insert(query.constraints, { op = "==", version = vers.parse_version(version)})
    end
    return query
 end
@@ -246,7 +246,7 @@ local function pick_latest_version(name, versions)
 
    local vtables = {}
    for v, _ in pairs(versions) do
-      table.insert(vtables, deps.parse_version(v))
+      table.insert(vtables, vers.parse_version(v))
    end
    table.sort(vtables)
    local version = vtables[#vtables].string
@@ -339,7 +339,7 @@ function search.print_results(results, porcelain)
       if not porcelain then
          util.printout(package)
       end
-      for version, repos in util.sortedpairs(versions, deps.compare_versions) do
+      for version, repos in util.sortedpairs(versions, vers.compare_versions) do
          for _, repo in ipairs(repos) do
             repo.repo = dir.normalize(repo.repo)
             if porcelain then
@@ -402,7 +402,7 @@ function search.pick_installed_rock(name, version, given_tree)
    local package, versions = util.sortedpairs(results)()
    --question: what do we do about multiple versions? This should
    --give us the latest version on the last repo (which is usually the global one)
-   for vs, repositories in util.sortedpairs(versions, deps.compare_versions) do
+   for vs, repositories in util.sortedpairs(versions, vers.compare_versions) do
       if not version then version = vs end
       for _, rp in ipairs(repositories) do repo_url = rp.repo end
    end

--- a/src/luarocks/util.lua
+++ b/src/luarocks/util.lua
@@ -387,7 +387,7 @@ local function collect_rockspecs(versions, paths, unnamed_paths, subdir)
    local fs = require("luarocks.fs")
    local dir = require("luarocks.dir")
    local path = require("luarocks.path")
-   local deps = require("luarocks.deps")
+   local vers = require("luarocks.vers")
 
    if fs.is_dir(subdir) then
       for file in fs.dir(subdir) do
@@ -397,7 +397,7 @@ local function collect_rockspecs(versions, paths, unnamed_paths, subdir)
             local rock, version = path.parse_name(file)
 
             if rock then
-               if not versions[rock] or deps.compare_versions(version, versions[rock]) then
+               if not versions[rock] or vers.compare_versions(version, versions[rock]) then
                   versions[rock] = version
                   paths[rock] = file
                end

--- a/src/luarocks/vers.lua
+++ b/src/luarocks/vers.lua
@@ -1,0 +1,138 @@
+
+--- Dependency format handling functions.
+-- Dependencies are represented in LuaRocks through strings with
+-- a package name followed by a comma-separated list of constraints.
+-- Each constraint consists of an operator and a version number.
+-- In this string format, version numbers are represented as
+-- naturally as possible, like they are used by upstream projects
+-- (e.g. "2.0beta3"). Internally, LuaRocks converts them to a purely
+-- numeric representation, allowing comparison following some
+-- "common sense" heuristics. The precise specification of the
+-- comparison criteria is the source code of this module.
+local vers = {}
+setmetatable(vers, { __index = require("luarocks.core.vers") })
+
+--- Check if rockspec format version satisfies version requirement.
+-- @param rockspec table: The rockspec table.
+-- @param version string: required version.
+-- @return boolean: true if rockspec format matches version or is newer, false otherwise.
+function vers.format_is_at_least(rockspec, version)
+   local rockspec_format = rockspec.rockspec_format or "1.0"
+   return vers.parse_version(rockspec_format) >= vers.parse_version(version)
+end
+
+local operators = {
+   ["=="] = "==",
+   ["~="] = "~=",
+   [">"] = ">",
+   ["<"] = "<",
+   [">="] = ">=",
+   ["<="] = "<=",
+   ["~>"] = "~>",
+   -- plus some convenience translations
+   [""] = "==",
+   ["="] = "==",
+   ["!="] = "~="
+}
+
+--- Consumes a constraint from a string, converting it to table format.
+-- For example, a string ">= 1.0, > 2.0" is converted to a table in the
+-- format {op = ">=", version={1,0}} and the rest, "> 2.0", is returned
+-- back to the caller.
+-- @param input string: A list of constraints in string format.
+-- @return (table, string) or nil: A table representing the same
+-- constraints and the string with the unused input, or nil if the
+-- input string is invalid.
+local function parse_constraint(input)
+   assert(type(input) == "string")
+
+   local no_upgrade, op, version, rest = input:match("^(@?)([<>=~!]*)%s*([%w%.%_%-]+)[%s,]*(.*)")
+   local _op = operators[op]
+   version = vers.parse_version(version)
+   if not _op then
+      return nil, "Encountered bad constraint operator: '"..tostring(op).."' in '"..input.."'"
+   end
+   if not version then 
+      return nil, "Could not parse version from constraint: '"..input.."'"
+   end
+   return { op = _op, version = version, no_upgrade = no_upgrade=="@" and true or nil }, rest
+end
+
+--- Convert a list of constraints from string to table format.
+-- For example, a string ">= 1.0, < 2.0" is converted to a table in the format
+-- {{op = ">=", version={1,0}}, {op = "<", version={2,0}}}.
+-- Version tables use a metatable allowing later comparison through
+-- relational operators.
+-- @param input string: A list of constraints in string format.
+-- @return table or nil: A table representing the same constraints,
+-- or nil if the input string is invalid.
+function vers.parse_constraints(input)
+   assert(type(input) == "string")
+
+   local constraints, oinput, constraint = {}, input
+   while #input > 0 do
+      constraint, input = parse_constraint(input)
+      if constraint then
+         table.insert(constraints, constraint)
+      else
+         return nil, "Failed to parse constraint '"..tostring(oinput).."' with error: ".. input
+      end
+   end
+   return constraints
+end
+
+--- Convert a dependency from string to table format.
+-- For example, a string "foo >= 1.0, < 2.0"
+-- is converted to a table in the format
+-- {name = "foo", constraints = {{op = ">=", version={1,0}},
+-- {op = "<", version={2,0}}}}. Version tables use a metatable
+-- allowing later comparison through relational operators.
+-- @param dep string: A dependency in string format
+-- as entered in rockspec files.
+-- @return table or nil: A table representing the same dependency relation,
+-- or nil if the input string is invalid.
+function vers.parse_dep(dep)
+   assert(type(dep) == "string")
+
+   local name, rest = dep:match("^%s*([a-zA-Z0-9][a-zA-Z0-9%.%-%_]*)%s*(.*)")
+   if not name then return nil, "failed to extract dependency name from '"..tostring(dep).."'" end
+   local constraints, err = vers.parse_constraints(rest)
+   if not constraints then return nil, err end
+   return { name = name, constraints = constraints }
+end
+
+--- Convert a version table to a string.
+-- @param v table: The version table
+-- @param internal boolean or nil: Whether to display versions in their
+-- internal representation format or how they were specified.
+-- @return string: The dependency information pretty-printed as a string.
+function vers.show_version(v, internal)
+   assert(type(v) == "table")
+   assert(type(internal) == "boolean" or not internal)
+
+   return (internal
+           and table.concat(v, ":")..(v.revision and tostring(v.revision) or "")
+           or v.string)
+end
+
+--- Convert a dependency in table format to a string.
+-- @param dep table: The dependency in table format
+-- @param internal boolean or nil: Whether to display versions in their
+-- internal representation format or how they were specified.
+-- @return string: The dependency information pretty-printed as a string.
+function vers.show_dep(dep, internal)
+   assert(type(dep) == "table")
+   assert(type(internal) == "boolean" or not internal)
+
+   if #dep.constraints > 0 then
+      local pretty = {}
+      for _, c in ipairs(dep.constraints) do
+         table.insert(pretty, c.op .. " " .. vers.show_version(c.version, internal))
+      end
+      return dep.name.." "..table.concat(pretty, ", ")
+   else
+      return dep.name
+   end
+end
+
+return vers


### PR DESCRIPTION
luarocks.deps module used to contain version and dependency parsing
functions as well as some high-level dependency handling:
matching and resolving them. A lot of modules only need the parsing
half. Split it into its own module, luarocks.vers. Also remove a workaround for a cyclic dependency
between fetch, deps and manif.