### PR TITLE
Check cache owner

### DIFF
--- a/src/luarocks/command_line.lua
+++ b/src/luarocks/command_line.lua
@@ -187,7 +187,9 @@ function command_line.run_command(...)
       util.warning("The directory '" .. cfg.local_cache .. "' or its parent directory "..
                    "is not owned by the current user and the cache has been disabled. "..
                    "Please check the permissions and owner of that directory. "..
-                   "If executing pip with sudo, you may want sudo's -H flag.")
+                   (cfg.is_platform("unix")
+                    and ("If executing "..util.this_program("luarocks").." with sudo, you may want sudo's -H flag.")
+                    or ""))
       cfg.local_cache = fs.make_temp_dir("local_cache")
       util.schedule_function(fs.delete, cfg.local_cache)
    end

--- a/src/luarocks/command_line.lua
+++ b/src/luarocks/command_line.lua
@@ -178,8 +178,18 @@ function command_line.run_command(...)
       end
    end
 
-   if not fs.current_dir() or fs.current_dir() == "" then
+   if (not fs.current_dir()) or fs.current_dir() == "" then
       die("Current directory does not exist. Please run LuaRocks from an existing directory.")
+   end
+
+   if fs.attributes(cfg.local_cache, "owner") ~= fs.current_user() or
+      fs.attributes(dir.dir_name(cfg.local_cache), "owner") ~= fs.current_user() then
+      util.warning("The directory '" .. cfg.local_cache .. "' or its parent directory "..
+                   "is not owned by the current user and the cache has been disabled. "..
+                   "Please check the permissions and owner of that directory. "..
+                   "If executing pip with sudo, you may want sudo's -H flag.")
+      cfg.local_cache = fs.make_temp_dir("local_cache")
+      util.schedule_function(fs.delete, cfg.local_cache)
    end
    
    if commands[command] then

--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -411,7 +411,8 @@ local defaults = {
       SEVENZ = "7z",
 
       RSYNCFLAGS = "--exclude=.git -Oavz",
-      STATFLAG = "-c '%a'",
+      STATPERMFLAG = "-c '%a'",
+      STATOWNERFLAG = "-c '%U'",
       CURLNOCERTFLAG = "",
       WGETNOCERTFLAG = "",
    },
@@ -586,7 +587,8 @@ end
 
 if cfg.platforms.bsd then
    defaults.variables.MAKE = "gmake"
-   defaults.variables.STATFLAG = "-f '%OLp'"
+   defaults.variables.STATPERMFLAG = "-f '%OLp'"
+   defaults.variables.STATOWNERFLAG = "-f '%Su'"
 end
 
 if cfg.platforms.macosx then

--- a/src/luarocks/fs/lua.lua
+++ b/src/luarocks/fs/lua.lua
@@ -293,7 +293,7 @@ function fs_lua.copy(src, dest, perms)
    if destmode == "directory" then
       dest = dir.path(dest, dir.base_name(src))
    end
-   if not perms then perms = fs.get_permissions(src) end
+   if not perms then perms = fs.attributes(src, "permissions") end
    local src_h, err = io.open(src, "rb")
    if not src_h then return nil, err end
    local dest_h, err = io.open(dest, "w+b")
@@ -758,8 +758,18 @@ function fs_lua.chmod(file, mode)
    return err == 0
 end
 
-function fs_lua.get_permissions(file)
-   return posix.stat(file, "mode")
+function fs_lua.attributes(file, attrtype)
+   if attrtype == "permissions" then
+      return posix.stat(file, "mode")
+   elseif attrtype == "owner" then
+      return posix.getpwuid(posix.stat(file, "uid")).pw_name
+   else
+      return ""
+   end
+end
+
+function fs_lua.current_user()
+   return posix.getpwuid(posix.geteuid()).pw_name
 end
 
 --- Create a temporary directory.

--- a/src/luarocks/fs/unix.lua
+++ b/src/luarocks/fs/unix.lua
@@ -132,4 +132,8 @@ function unix.tmpname()
    return os.tmpname()
 end
 
+function unix.current_user()
+   return os.getenv("USER")
+end
+
 return unix

--- a/src/luarocks/fs/unix/tools.lua
+++ b/src/luarocks/fs/unix/tools.lua
@@ -200,8 +200,11 @@ function tools.unpack_archive(archive)
    return true
 end
 
-function tools.get_permissions(filename)
-   local pipe = io.popen(vars.STAT.." "..vars.STATFLAG.." "..fs.Q(filename))
+function tools.attributes(filename, attrtype)
+   local flag = ((attrtype == "permissions") and vars.STATPERMFLAG)
+             or ((attrtype == "owner") and vars.STATOWNERFLAG)
+   if not flag then return "" end
+   local pipe = io.popen(vars.STAT.." "..flag.." "..fs.Q(filename))
    local ret = pipe:read("*l")
    pipe:close()
    return ret

--- a/src/luarocks/fs/win32.lua
+++ b/src/luarocks/fs/win32.lua
@@ -191,7 +191,12 @@ function win32.chmod(filename, mode)
    return true
 end
 
-function win32.get_permissions(filename)
+function win32.attributes(filename, attrtype)
+   if attrtype == "permissions" then
+      return "" -- FIXME
+   elseif attrtype == "owner" then
+      return os.getenv("USERNAME") -- FIXME popen_read('powershell -Command "& {(get-acl '..filename..').owner}"'):gsub("^[^\\]*\\", "")
+   end
    return ""
 end
 
@@ -261,6 +266,10 @@ end
 
 function win32.tmpname()
    return os.getenv("TMP")..os.tmpname()
+end
+
+function win32.current_user()
+   return os.getenv("USERNAME")
 end
 
 return win32


### PR DESCRIPTION
Check ownership of cache directory and emit a warning. This prevents `sudo luarocks` to take over ownership of the user's ~/.cache/luarocks directory.

This is a blatant copy of pip's equivalent feature, down to the error message. :)