### PR TITLE
Added LPeg dependency for lxsh to luarocks make tests

### DIFF
--- a/spec/make_spec.lua
+++ b/spec/make_spec.lua
@@ -9,6 +9,7 @@ test_env.unload_luarocks()
 local extra_rocks = {
    "/luasocket-3.0rc1-2.src.rock",
    "/luasocket-3.0rc1-2.rockspec",
+   "/lpeg-0.12-1.src.rock",
    "/lxsh-0.8.6-2.src.rock",
    "/lxsh-0.8.6-2.rockspec"
 }


### PR DESCRIPTION
When you run just `luarocks make` tests, with `-t b_make` you get these errs:

```
[ENVIRONMENT RESET]

[EXECUTING]: '/usr/local/bin/lua' -e "require('luacov.runner')('/Users/roboo/WORK/GSoC17/luarocks/test/luacov.config')" /Users/roboo/WORK/GSoC17/luarocks/src/bin/luarocks download --source lxsh 0.8.6-2

[EXECUTING]: '/usr/local/bin/lua' -e "require('luacov.runner')('/Users/roboo/WORK/GSoC17/luarocks/test/luacov.config')" /Users/roboo/WORK/GSoC17/luarocks/src/bin/luarocks unpack lxsh-0.8.6-2.src.rock

[EXECUTING]: '/usr/local/bin/lua' -e "require('luacov.runner')('/Users/roboo/WORK/GSoC17/luarocks/test/luacov.config')" /Users/roboo/WORK/GSoC17/luarocks/src/bin/luarocks make

Error: Could not satisfy dependency lpeg >= 0.9: No results matching query were found.
Missing dependencies for lxsh 0.8.6-2:
   lpeg >= 0.9 (not installed)

lxsh 0.8.6-2 depends on lpeg >= 0.9 (not installed)

◼
[ENVIRONMENT RESET]

[EXECUTING]: '/usr/local/bin/lua' -e "require('luacov.runner')('/Users/roboo/WORK/GSoC17/luarocks/test/luacov.config')" /Users/roboo/WORK/GSoC17/luarocks/src/bin/luarocks download --source lxsh 0.8.6-2

[EXECUTING]: '/usr/local/bin/lua' -e "require('luacov.runner')('/Users/roboo/WORK/GSoC17/luarocks/test/luacov.config')" /Users/roboo/WORK/GSoC17/luarocks/src/bin/luarocks unpack lxsh-0.8.6-2.src.rock

[EXECUTING]: '/usr/local/bin/lua' -e "require('luacov.runner')('/Users/roboo/WORK/GSoC17/luarocks/test/luacov.config')" /Users/roboo/WORK/GSoC17/luarocks/src/bin/luarocks make

[EXECUTING]: '/usr/local/bin/lua' -e "require('luacov.runner')('/Users/roboo/WORK/GSoC17/luarocks/test/luacov.config')" /Users/roboo/WORK/GSoC17/luarocks/src/bin/luarocks show lxsh

Error: cannot find package lxsh
Use 'list' to find installed rocks.

==========================================================================

Failure → spec/make_spec.lua @ 60
LuaRocks make tests #blackbox #b_make LuaRocks making rockspecs (using lxsh) LuaRocks make default rockspec
spec/make_spec.lua:62: Expected objects to be the same.
Passed in:
(boolean) false
Expected:
(boolean) true

Failure → spec/make_spec.lua @ 68
LuaRocks make tests #blackbox #b_make LuaRocks making rockspecs (using lxsh) LuaRocks make unnamed rockspec
spec/make_spec.lua:70: Expected objects to be the same.
Passed in:
(boolean) false
Expected:
(boolean) true
```