### PR TITLE
tools.delete does not work with files

### DIFF
--- a/src/luarocks/fs/win32/tools.lua
+++ b/src/luarocks/fs/win32/tools.lua
@@ -93,7 +93,7 @@ end
 function tools.delete(arg)
    assert(arg)
    assert(arg:match("^[a-zA-Z]?:?[\\/]"))
-   fs.execute_quiet("if exist "..fs.Q(arg.."\\").." ( RMDIR /S /Q "..fs.Q(arg).." ) else ( DEL /Q /F "..fs.Q(arg).." )")
+   fs.execute_quiet("if exist "..fs.Q(arg.."\\*").." ( RMDIR /S /Q "..fs.Q(arg).." ) else ( DEL /Q /F "..fs.Q(arg).." )")
 end
 
 --- Recursively scan the contents of a directory.


### PR DESCRIPTION
Function tools.delete performs a test to determine if a path is a file or a directory to select the appropriate delete command `rmdir` vs `del`.
The current test however results in `rmdir` being used on files too, which then results in a build abortion with error `The directory name is invalid.`. 

E.g. `if exist "c:\luarocks\share\lua\5.2\luasocket_3_0rc1_2-socket.lua\" ( echo "I am a folder" ) else ( echo "I am a file" )` wrongly prints `I am a folder` (tested on Windows 10)

Whereas `if exist "c:\luarocks\share\lua\5.2\luasocket_3_0rc1_2-socket.lua\*" ( echo "I am a folder" ) else ( echo "I am a file" )` correctly prints `I am a file` (tested on Windows 10)

This fixes #670