### PR TITLE
Add "lib?.lib" as a library pattern

### DIFF
--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -465,7 +465,7 @@ if cfg.platforms.windows then
 
    defaults.external_deps_patterns = {
       bin = { "?.exe", "?.bat" },
-      lib = { "?.lib", "?.dll", "lib?.dll" },
+      lib = { "?.lib", "?.dll", "lib?.lib", "lib?.dll" },
       include = { "?.h" }
    }
    defaults.runtime_external_deps_patterns = {


### PR DESCRIPTION
OpenSSL installs found [here](http://slproweb.com/products/Win32OpenSSL.html) have filenames such as `libssl.lib`, `libcrypto.lib`.

Fixes https://github.com/luarocks/luarocks/issues/756.