### PR TITLE
Fix .def generation on Windows.

### DIFF
--- a/src/luarocks/build/builtin.lua
+++ b/src/luarocks/build/builtin.lua
@@ -122,8 +122,10 @@ function builtin.run(rockspec)
          local basename = dir.base_name(library):gsub(".[^.]*$", "")
          local deffile = basename .. ".def"
          local def = io.open(dir.path(fs.current_dir(), deffile), "w+")
+         local exported_name = name:gsub("%.", "_")
+         exported_name = exported_name:match('^[^%-]+%-(.+)$') or exported_name
          def:write("EXPORTS\n")
-         def:write("luaopen_"..name:gsub("%.", "_").."\n")
+         def:write("luaopen_"..exported_name.."\n")
          def:close()
          local ok = execute(variables.LD, "-dll", "-def:"..deffile, "-out:"..library, dir.path(variables.LUA_LIBDIR, variables.LUALIB), unpack(extras))
          local basedir = ""


### PR DESCRIPTION
According to the Lua's manual:

> Once it finds a C library, this searcher first uses a dynamic link facility to link the application with the library. Then it tries to find a C function inside the library to be used as the loader. The name of this C function is the string "luaopen_" concatenated with a copy of the module name where each dot is replaced by an underscore. Moreover, if the module name has a hyphen, its prefix up to (and including) the first hyphen is removed. For instance, if the module name is a.v1-b.c, the function name will be luaopen_b_c.