### PR TITLE
Handle broken site_config

### DIFF
--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -20,7 +20,10 @@ local version_suffix = cfg.lua_version:gsub("%.", "_")
 
 -- Load site-local global configurations
 local ok, site_config = pcall(require, "luarocks.core.site_config_"..version_suffix)
-if not ok then
+if type(site_config) ~= "table" then
+   io.stderr:write("Result of require('luarocks.core.site_config_"..version_suffix.."') was invalid.\n")
+   site_config = {}
+elseif not ok then
    io.stderr:write("Site-local luarocks/core/site_config_"..version_suffix..".lua file not found. Incomplete installation?\n")
    site_config = {}
 end


### PR DESCRIPTION
On travis CI the Neovim project sometimes sees errors [like this](https://api.travis-ci.org/v3/job/350986012/log.txt):

```
Using previously configured rocks dir: /home/travis/nvim-deps/usr/lib/luarocks/rocks
Writing configuration...

Installation prefix: /home/travis/nvim-deps/usr
LuaRocks configuration directory: /home/travis/nvim-deps/usr/etc/luarocks
Using Lua from: /home/travis/nvim-deps/usr

Done configuring.
- Type 'make build' and 'make install':
  to install to /home/travis/nvim-deps/usr as usual.
- Type 'make bootstrap':
  to install LuaRocks in /home/travis/nvim-deps/usr as a rock.

No build step for 'luarocks'
Performing install step for 'luarocks'
/home/travis/nvim-deps/usr/bin/luajit: ...travis/nvim-deps/build/src/luarocks/src/luarocks/cfg.lua:78: attempt to index local 'site_config' (a boolean value)
stack traceback:
	...travis/nvim-deps/build/src/luarocks/src/luarocks/cfg.lua:78: in main chunk
	[C]: in function 'require'
	src/bin/luarocks:4: in main chunk
	[C]: at 0x0804c1b0
make[3]: *** [run_luarocks] Error 1
make[3]: *** Waiting for unfinished jobs....
make[2]: *** [build/src/luarocks-stamp/luarocks-install] Error 2
make[1]: *** [CMakeFiles/luarocks.dir/all] Error 2
make: *** [all] Error 2
```

That "attempt to index local 'site_config' (a boolean value)" error is annoying and requires digging around to find why it might happen. 

`require()` returns `true` if the module doesn't return anything, so that's why `site_config` is "a boolean value".

Of course, the deeper problem[1] is that the `require()` is being weird. But showing a hint is better than nothing.  

[1] My guess is that `make bootstrap` is [doing things](https://github.com/luarocks/luarocks/blob/815cf73c266e371fe2eaa81787572564736e2b02/Makefile#L147) in parallel, maybe the site_config file is not fully written when the `require()` is invoked. Or travis (or the CI cache) is being weird.