### PR TITLE
Prepare for Lua 5.4

### DIFF
--- a/configure
+++ b/configure
@@ -39,7 +39,7 @@ system's package manager.
 --rocks-tree=DIR            Root of the local tree of installed rocks.
                             Default is \$PREFIX
 
---lua-version=VERSION       Use specific Lua version: 5.1, 5.2, or 5.3
+--lua-version=VERSION       Use specific Lua version: 5.1, 5.2, 5.3, or 5.4
                             Default is auto-detected.
 --lua-suffix=SUFFIX         Versioning suffix to use in Lua filenames.
                             Default is "$LUA_SUFFIX" (lua$LUA_SUFFIX...)
@@ -163,7 +163,7 @@ do
    --lua-version|--with-lua-version)
       [ -n "$value" ] || die "Missing value in flag $key."
       LUA_VERSION="$value"
-      [ "$LUA_VERSION" = "5.1" -o "$LUA_VERSION" = "5.2" -o "$LUA_VERSION" = "5.3" ] || die "Invalid Lua version in flag $key."
+      [ "$LUA_VERSION" = "5.1" -o "$LUA_VERSION" = "5.2" -o "$LUA_VERSION" = "5.3" -o "$LUA_VERSION" = "5.4" ] || die "Invalid Lua version in flag $key."
       LUA_VERSION_SET=yes
       ;;
    --with-lua)
@@ -224,7 +224,7 @@ then
 fi
 
 detect_lua_version() {
-   detected_lua=`$1 -e 'print(_VERSION:match(" (5%.[123])$"))' 2> /dev/null`
+   detected_lua=`$1 -e 'print(_VERSION:match(" (5%.[1234])$"))' 2> /dev/null`
    if [ "$detected_lua" != "nil" ]
    then
       if [ "$LUA_VERSION_SET" != "yes" ]
@@ -286,9 +286,12 @@ then
       suffixes="5.2 52 -5.2 -52"
    elif [ "$LUA_VERSION_SET" = "yes" -a "$LUA_VERSION" = "5.3" ]
    then
+      suffixes="5.4 54 -5.4 -54"
+   elif [ "$LUA_VERSION_SET" = "yes" -a "$LUA_VERSION" = "5.4" ]
+   then
       suffixes="5.3 53 -5.3 -53"
    else
-      suffixes="5.3 53 -5.3 -53 5.2 52 -5.2 -52 5.1 51 -5.1 -51"
+      suffixes="5.4 54 -5.4 -54 5.3 53 -5.3 -53 5.2 52 -5.2 -52 5.1 51 -5.1 -51"
    fi
    for suffix in `echo $suffixes` ""
    do
@@ -400,7 +403,7 @@ else
    die "Could not determine processor architecture. 'uname -m' failed."
 fi
 
-for v in 5.1 5.2 5.3; do
+for v in 5.1 5.2 5.3 5.4; do
   if [ "$v" != "$LUA_VERSION" ]; then
     if [ -e "$PREFIX/share/lua/$v/luarocks/site_config.lua" ]; then
       LUA_OTHER_VERSION="$v"

--- a/src/luarocks/cmd/write_rockspec.lua
+++ b/src/luarocks/cmd/write_rockspec.lua
@@ -33,8 +33,9 @@ rockspec, and is not guaranteed to be complete or correct.
 --summary="<txt>"        A short one-line description summary.
 --detailed="<txt>"       A longer description string.
 --homepage=<url>         Project homepage.
---lua-version=<ver>      Supported Lua versions. Accepted values are "5.1", "5.2",
-                         "5.3", "5.1,5.2", "5.2,5.3", or "5.1,5.2,5.3".
+--lua-version=<ver>      Supported Lua versions.  Accepted values are: "5.1", "5.2",
+                         "5.3", "5.4", "5.1,5.2", "5.2,5.3", "5.3,5.4", "5.1,5.2,5.3",
+                         "5.2,5.3,5.4", or "5.1,5.2,5.3,5.4"
 --rockspec-format=<ver>  Rockspec format version, such as "1.0" or "1.1".
 --tag=<tag>              Tag to use. Will attempt to extract version number from it.
 --lib=<lib>[,<lib>]      A comma-separated list of libraries that C files need to
@@ -68,12 +69,20 @@ local function configure_lua_version(rockspec, luaver)
       table.insert(rockspec.dependencies, "lua ~> 5.2")
    elseif luaver == "5.3" then
       table.insert(rockspec.dependencies, "lua ~> 5.3")
+   elseif luaver == "5.4" then
+      table.insert(rockspec.dependencies, "lua ~> 5.4")
    elseif luaver == "5.1,5.2" then
       table.insert(rockspec.dependencies, "lua >= 5.1, < 5.3")
    elseif luaver == "5.2,5.3" then
       table.insert(rockspec.dependencies, "lua >= 5.2, < 5.4")
+   elseif luaver == "5.3,5.4" then
+      table.insert(rockspec.dependencies, "lua >= 5.3, < 5.5")
    elseif luaver == "5.1,5.2,5.3" then
       table.insert(rockspec.dependencies, "lua >= 5.1, < 5.4")
+   elseif luaver == "5.2,5.3,5.4" then
+      table.insert(rockspec.dependencies, "lua >= 5.2, < 5.5")
+   elseif luaver == "5.1,5.2,5.3,5.4" then
+      table.insert(rockspec.dependencies, "lua >= 5.1, < 5.5")
    else
       util.warning("Please specify supported Lua version with --lua-version=<ver>. "..util.see_help("write_rockspec"))
    end

--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -15,7 +15,7 @@ local rawset, next, table, pairs, require, io, os, setmetatable, pcall, ipairs, 
 
 local cfg = {}
 
-cfg.lua_version = _VERSION:match(" (5%.[123])$") or "5.1"
+cfg.lua_version = _VERSION:match(" (5%.[1234])$") or "5.1"
 local version_suffix = cfg.lua_version:gsub("%.", "_")
 
 -- Load site-local global configurations

--- a/src/luarocks/util.lua
+++ b/src/luarocks/util.lua
@@ -310,7 +310,7 @@ function util.variable_substitutions(tbl, vars)
 end
 
 function util.lua_versions()
-   local versions = { "5.1", "5.2", "5.3" }
+   local versions = { "5.1", "5.2", "5.3", "5.4" }
    local i = 0
    return function()
       i = i + 1


### PR DESCRIPTION
This whitelists the upcoming Lua 5.4 version in various places, which helps if you want to test both luarocks itself and other Lua modules, rocks, etc.