### PR TITLE
Tests: cache some binary rocks to speed up tests

### DIFF
--- a/spec/build_spec.lua
+++ b/spec/build_spec.lua
@@ -5,7 +5,7 @@ local testing_paths = test_env.testing_paths
 
 test_env.unload_luarocks()
 
-local extra_rocks = test_env.mock_server_extra_rocks({
+local extra_rocks = {
    "/lmathx-20120430.51-1.src.rock",
    "/lmathx-20120430.51-1.rockspec",
    "/lmathx-20120430.52-1.src.rock",
@@ -26,7 +26,7 @@ local extra_rocks = test_env.mock_server_extra_rocks({
    "/lxsh-0.8.6-2.rockspec",
    "/stdlib-41.0.0-1.src.rock",
    "/validate-args-1.5.4-1.rockspec"
-})
+}
 
 describe("LuaRocks build tests #blackbox #b_build", function()
 

--- a/spec/new_version_spec.lua
+++ b/spec/new_version_spec.lua
@@ -5,10 +5,10 @@ local testing_paths = test_env.testing_paths
 
 test_env.unload_luarocks()
 
-local extra_rocks = test_env.mock_server_extra_rocks({
+local extra_rocks = {
    "/abelhas-1.1-1.rockspec",
    "/lpeg-0.12-1.rockspec"
-})
+}
 
 describe("LuaRocks new_version tests #blackbox #b_new_version", function()
 

--- a/spec/pack_spec.lua
+++ b/spec/pack_spec.lua
@@ -5,14 +5,14 @@ local testing_paths = test_env.testing_paths
 
 test_env.unload_luarocks()
 
-local extra_rocks = test_env.mock_server_extra_rocks({
+local extra_rocks = {
    "/luasec-0.6-1.rockspec",
    "/luassert-1.7.0-1.src.rock",
    "/luasocket-3.0rc1-2.src.rock",
    "/luasocket-3.0rc1-2.rockspec",
    "/say-1.2-1.src.rock",
    "/say-1.0-1.src.rock"
-})
+}
 
 describe("LuaRocks pack #blackbox #b_pack", function()
 
@@ -50,14 +50,7 @@ describe("LuaRocks pack #blackbox #b_pack", function()
       assert(test_env.remove_files(lfs.currentdir(), "say%-"))
    end)
 
-   it("src", function()
-      assert(run.luarocks_bool("install luasec " .. test_env.OPENSSL_DIRS))
-      assert(run.luarocks_bool("download --rockspec luasocket 3.0rc1-2"))
-      assert(run.luarocks_bool("pack luasocket-3.0rc1-2.rockspec"))
-      assert(test_env.remove_files(lfs.currentdir(), "luasocket%-"))
-   end)
-   
-   describe("#mock namespaced dependencies", function()
+   describe("#mock", function()
 
       setup(function()
          test_env.mock_server_init()
@@ -67,12 +60,23 @@ describe("LuaRocks pack #blackbox #b_pack", function()
          test_env.mock_server_done()
       end)
 
-      it("can pack rockspec with namespaced dependencies", function()
+      it("can pack a rockspec into a .src.rock", function()
          finally(function()
-            os.remove("has_namespaced_dep-1.0-1.src.rock")
+            os.remove("a_rock-1.0-1.src.rock")
          end)
-         assert(run.luarocks_bool("pack " .. testing_paths.fixtures_dir .. "/a_repo/has_namespaced_dep-1.0-1.rockspec"))
-         assert.is_truthy(lfs.attributes("has_namespaced_dep-1.0-1.src.rock"))
+         assert(run.luarocks_bool("download --rockspec --server=" .. testing_paths.fixtures_dir .. "/a_repo a_rock 1.0-1"))
+         assert(run.luarocks_bool("pack a_rock-1.0-1.rockspec"))
+         assert.is_truthy(lfs.attributes("a_rock-1.0-1.src.rock"))
+      end)
+      
+      describe("namespaced dependencies", function()
+         it("can pack rockspec with namespaced dependencies", function()
+            finally(function()
+               os.remove("has_namespaced_dep-1.0-1.src.rock")
+            end)
+            assert(run.luarocks_bool("pack " .. testing_paths.fixtures_dir .. "/a_repo/has_namespaced_dep-1.0-1.rockspec"))
+            assert.is_truthy(lfs.attributes("has_namespaced_dep-1.0-1.src.rock"))
+         end)
       end)
    end)
 

--- a/spec/test_spec.lua
+++ b/spec/test_spec.lua
@@ -35,6 +35,27 @@ describe("luarocks test #blackbox #b_test", function()
    end)
 
    describe("busted backend", function()
+
+      setup(function()
+         -- Try to cache rocks from the host system to speed up test
+         os.execute("luarocks pack busted")
+         os.execute("luarocks pack lua_cliargs")
+         os.execute("luarocks pack luafilesystem")
+         os.execute("luarocks pack dkjson")
+         os.execute("luarocks pack luasystem")
+         os.execute("luarocks pack say")
+         os.execute("luarocks pack luassert")
+         os.execute("luarocks pack lua-term")
+         os.execute("luarocks pack penlight")
+         os.execute("luarocks pack mediator_lua")
+         if test_env.TEST_TARGET_OS == "windows" then
+            os.execute("move *.rock " .. testing_paths.testing_server)
+         else
+            os.execute("mv *.rock " .. testing_paths.testing_server)
+         end
+         test_env.run.luarocks_admin_nocov("make_manifest " .. testing_paths.testing_server)
+      end)
+
       it("with rockspec, installing busted", function()
          finally(function()
             -- delete downloaded and unpacked files

--- a/spec/upload_spec.lua
+++ b/spec/upload_spec.lua
@@ -4,12 +4,10 @@ local testing_paths = test_env.testing_paths
 
 test_env.unload_luarocks()
 
-local extra_rocks = test_env.mock_server_extra_rocks()
-
 describe("LuaRocks upload tests #blackbox #b_upload", function()
 
    before_each(function()
-      test_env.setup_specs(extra_rocks)
+      test_env.setup_specs()
    end)
 
    it("LuaRocks upload with no flags/arguments", function()

--- a/spec/write_rockspec_spec.lua
+++ b/spec/write_rockspec_spec.lua
@@ -3,8 +3,6 @@ local git_repo = require("spec.util.git_repo")
 local lfs = require("lfs")
 local run = test_env.run
 
-local extra_rocks = test_env.mock_server_extra_rocks()
-
 describe("LuaRocks write_rockspec tests #blackbox #b_write_rockspec", function()
 
    before_each(function()
@@ -79,7 +77,6 @@ describe("LuaRocks write_rockspec tests #blackbox #b_write_rockspec", function()
    describe("from tarball #mock", function()
 
       setup(function()
-         test_env.setup_specs(extra_rocks)
          test_env.mock_server_init()
       end)
       teardown(function()


### PR DESCRIPTION
The Linux job for "lua=5.1" on Travis went to about 159s to 142s.
The Windows job for "lua=5.1,msvc" on Appveyor went from about 654s to 569s.

Since Appveyor does not run jobs in parallel, the gains are considerable. Total Appveyor time went from 1h40 to 2h20 once all mock-server tests were enabled; this at least brings the total time down to the previous ballpark.