### PR TITLE
New command: luarocks init

### DIFF
--- a/Makefile.setup.inc
+++ b/Makefile.setup.inc
@@ -23,5 +23,5 @@ fetch/cvs.lua fetch/git_https.lua fetch/git_ssh.lua fetch/hg_http.lua \
 fetch/git_http.lua fetch/svn.lua fetch/git.lua fetch/hg_ssh.lua \
 fetch/hg_https.lua fetch/hg.lua core/vers.lua cmd/which.lua \
 fun.lua type/manifest.lua type/rockspec.lua queries.lua results.lua \
-test/busted.lua test/command.lua
+test/busted.lua test/command.lua cmd/init.lua
 

--- a/spec/list_spec.lua
+++ b/spec/list_spec.lua
@@ -40,6 +40,6 @@ describe("LuaRocks list tests #blackbox #b_list", function()
    
    it("LuaRocks list invalid tree", function()
       local output = run.luarocks("--tree=/some/invalid/tree list")
-      assert(output:find("Installed rocks for Lua "..test_env.lua_version, 1, true))
+      assert(output:find("Rocks installed for Lua "..test_env.lua_version.." in /some/invalid/tree", 1, true))
    end)
 end)

--- a/src/bin/luarocks
+++ b/src/bin/luarocks
@@ -10,6 +10,7 @@ program_description = "LuaRocks main command-line interface"
 
 commands = {
    help = "luarocks.cmd.help",
+   init = "luarocks.cmd.init",
    pack = "luarocks.cmd.pack",
    unpack = "luarocks.cmd.unpack",
    build = "luarocks.cmd.build",

--- a/src/luarocks/cmd/build.lua
+++ b/src/luarocks/cmd/build.lua
@@ -14,6 +14,7 @@ local cfg = require("luarocks.core.cfg")
 local build = require("luarocks.build")
 local writer = require("luarocks.manif.writer")
 local search = require("luarocks.search")
+local make = require("luarocks.cmd.make")
 
 cmd_build.help_summary = "build/compile a rock."
 cmd_build.help_arguments = "[--pack-binary-rock] [--keep] {<rockspec>|<rock>|<name> [<version>]}"
@@ -97,10 +98,12 @@ end
 -- @return boolean or (nil, string, exitcode): True if build was successful; nil and an
 -- error message otherwise. exitcode is optionally returned.
 function cmd_build.command(flags, name, version)
-   if type(name) ~= "string" then
-      return nil, "Argument missing. "..util.see_help("build")
-   end
+   assert(type(name) == "string" or not name)
    assert(type(version) == "string" or not version)
+   
+   if not name then
+      return make.command(flags)
+   end
 
    name = util.adjust_name_and_namespace(name, flags)
    local deps_mode = deps.get_deps_mode(flags)

--- a/src/luarocks/cmd/help.lua
+++ b/src/luarocks/cmd/help.lua
@@ -79,22 +79,25 @@ function help.command(flags, command)
       end
       print_section("CONFIGURATION")
       util.printout("\tLua version: " .. cfg.lua_version)
+      util.printout()
       util.printout("\tConfiguration files:")
       util.printout("\t\tSystem: ".. dir.normalize(conf.system.file) .. " (" .. get_status(conf.system.ok) ..")")
       if conf.user.file then
-         util.printout("\t\tUser  : ".. dir.normalize(conf.user.file) .. " (" .. get_status(conf.user.ok) ..")\n")
+         util.printout("\t\tUser  : ".. dir.normalize(conf.user.file) .. " (" .. get_status(conf.user.ok) ..")")
       else
-         util.printout("\t\tUser  : disabled in this LuaRocks installation.\n")
+         util.printout("\t\tUser  : disabled in this LuaRocks installation.")
       end
+      util.printout()
       util.printout("\tRocks trees in use: ")
       for _, tree in ipairs(cfg.rocks_trees) do
-      	if type(tree) == "string" then
-      	   util.printout("\t\t"..dir.normalize(tree))
-      	else
-      	   local name = tree.name and " (\""..tree.name.."\")" or ""
-      	   util.printout("\t\t"..dir.normalize(tree.root)..name)
-      	end
+         if type(tree) == "string" then
+            util.printout("\t\t"..dir.normalize(tree))
+         else
+            local name = tree.name and " (\""..tree.name.."\")" or ""
+            util.printout("\t\t"..dir.normalize(tree.root)..name)
+         end
       end
+      util.printout()
    else
       command = command:gsub("-", "_")
       local cmd = commands[command] and require(commands[command])

--- a/src/luarocks/cmd/init.lua
+++ b/src/luarocks/cmd/init.lua
@@ -1,0 +1,68 @@
+
+local init = {}
+
+local cfg = require("luarocks.core.cfg")
+local fs = require("luarocks.fs")
+local path = require("luarocks.path")
+local dir = require("luarocks.dir")
+local util = require("luarocks.util")
+local write_rockspec = require("luarocks.cmd.write_rockspec")
+
+init.help_summary = "Initialize a directory for a Lua project using LuaRocks."
+init.help_arguments = "[<name> [<version>]]"
+init.help = [[
+<name> is the project name.
+<version> is an optional project version.
+
+--license="<string>"     A license string, such as "MIT/X11" or "GNU GPL v3".
+--summary="<txt>"        A short one-line description summary.
+--detailed="<txt>"       A longer description string.
+--homepage=<url>         Project homepage.
+--lua-version=<ver>      Supported Lua versions. Accepted values are "5.1", "5.2",
+                         "5.3", "5.1,5.2", "5.2,5.3", or "5.1,5.2,5.3".
+--rockspec-format=<ver>  Rockspec format version, such as "1.0" or "1.1".
+--lib=<lib>[,<lib>]      A comma-separated list of libraries that C files need to
+                         link to.
+]]
+
+local function write_gitignore()
+   if fs.exists(".gitignore") then
+      return
+   end
+   local fd = io.open(".gitignore", "w")
+   fd:write("lua_modules\n")
+   fd:write("lua\n")
+   fd:close()
+end
+
+--- Driver function for "init" command.
+-- @return boolean: True if succeeded, nil on errors.
+function init.command(flags, name, version)
+
+   local pwd = fs.current_dir()
+
+   if not name then
+      name = dir.base_name(pwd)
+   end
+
+   util.printout("Initializing project " .. name)
+   
+   local ok, err = write_rockspec.command(flags, name, version or "dev", pwd)
+   if not ok then
+      util.printerr(err)
+   end
+   
+   write_gitignore()
+
+   fs.make_dir("lua_modules/lib/luarocks/rocks-" .. cfg.lua_version)
+   local tree = dir.path(pwd, "lua_modules")
+
+   fs.wrap_script(arg[0], "luarocks", nil, nil, "--tree", tree)
+
+   path.use_tree(tree)
+   fs.wrap_script(nil, "lua")
+
+   return true
+end
+
+return init

--- a/src/luarocks/cmd/init.lua
+++ b/src/luarocks/cmd/init.lua
@@ -55,9 +55,19 @@ function init.command(flags, name, version)
 
    util.printout("Initializing project " .. name .. " ...")
    
-   local ok, err = write_rockspec.command(flags, name, version or "dev", pwd)
-   if not ok then
-      util.printerr(err)
+   local has_rockspec = false
+   for file in fs.dir() do
+      if file:match("%.rockspec$") then
+         has_rockspec = true
+         break
+      end
+   end
+
+   if not has_rockspec then
+      local ok, err = write_rockspec.command(flags, name, version or "dev", pwd)
+      if not ok then
+         util.printerr(err)
+      end
    end
    
    util.printout("Adding entries to .gitignore ...")

--- a/src/luarocks/cmd/init.lua
+++ b/src/luarocks/cmd/init.lua
@@ -77,14 +77,20 @@ function init.command(flags, name, version)
    fs.make_dir("lua_modules/lib/luarocks/rocks-" .. cfg.lua_version)
    local tree = dir.path(pwd, "lua_modules")
 
-   util.printout("Preparing ./luarocks ...")
+   local ext = cfg.wrapper_suffix
 
-   fs.wrap_script(arg[0], "luarocks", nil, nil, "--project-tree", tree)
+   local luarocks_wrapper = "./luarocks" .. ext
+   if not fs.exists(luarocks_wrapper) then
+      util.printout("Preparing " .. luarocks_wrapper .. " ...")
+      fs.wrap_script(arg[0], "luarocks", nil, nil, "--project-tree", tree)
+   end
 
-   util.printout("Preparing ./lua ...")
-
-   path.use_tree(tree)
-   fs.wrap_script(nil, "lua")
+   local lua_wrapper = "./lua" .. ext
+   if not fs.exists(lua_wrapper) then
+      util.printout("Preparing " .. lua_wrapper .. " ...")
+      path.use_tree(tree)
+      fs.wrap_script(nil, "lua")
+   end
 
    return true
 end

--- a/src/luarocks/cmd/list.lua
+++ b/src/luarocks/cmd/list.lua
@@ -71,8 +71,10 @@ end
 function list.command(flags, filter, version)
    local query = queries.new(filter and filter:lower() or "", version, true)
    local trees = cfg.rocks_trees
+   local title = "Rocks installed for Lua "..cfg.lua_version
    if flags["tree"] then
       trees = { flags["tree"] }
+      title = title .. " in " .. flags["tree"]
    end
    
    if flags["outdated"] then
@@ -86,7 +88,7 @@ function list.command(flags, filter, version)
          util.warning(err)
       end
    end
-   util.title("Installed rocks for Lua "..cfg.lua_version..":", flags["porcelain"])
+   util.title(title, flags["porcelain"])
    search.print_result_tree(results, flags["porcelain"])
    return true
 end

--- a/src/luarocks/cmd/path.lua
+++ b/src/luarocks/cmd/path.lua
@@ -58,18 +58,7 @@ function path_cmd.command(flags)
       lr_bin = lr_bin .. path_sep .. os.getenv("PATH")
    end
    
-   local lpath_var = "LUA_PATH"
-   local lcpath_var = "LUA_CPATH"
-   
-   local lv = cfg.lua_version:gsub("%.", "_")
-   if lv ~= "5_1" then
-      if os.getenv("LUA_PATH_" .. lv) then
-         lpath_var = "LUA_PATH_" .. lv
-      end
-      if os.getenv("LUA_CPATH_" .. lv) then
-         lcpath_var = "LUA_CPATH_" .. lv
-      end
-   end
+   local lpath_var, lcpath_var = util.lua_path_variables()
 
    util.printout(fs.export_cmd(lpath_var, util.cleanup_path(lr_path, ';', cfg.lua_version)))
    util.printout(fs.export_cmd(lcpath_var, util.cleanup_path(lr_cpath, ';', cfg.lua_version)))

--- a/src/luarocks/command_line.lua
+++ b/src/luarocks/command_line.lua
@@ -131,6 +131,10 @@ function command_line.run_command(...)
      cfg.branch = flags["branch"]
    end
    
+   if flags["project-tree"] then
+      table.insert(cfg.rocks_trees, 1, { name = "project", root = flags["project-tree"] } )
+   end
+
    if flags["tree"] then
       local named = false
       for _, tree in ipairs(cfg.rocks_trees) do

--- a/src/luarocks/command_line.lua
+++ b/src/luarocks/command_line.lua
@@ -144,6 +144,11 @@ function command_line.run_command(...)
    
    if flags["project-tree"] then
       table.insert(cfg.rocks_trees, 1, { name = "project", root = flags["project-tree"] } )
+   else
+      local project_dir, rocks_tree = find_project_dir()
+      if project_dir then
+         table.insert(cfg.rocks_trees, 1, { name = "project", root = rocks_tree } )
+      end
    end
 
    if flags["tree"] then
@@ -170,13 +175,8 @@ function command_line.run_command(...)
       end
       replace_tree(flags, cfg.home_tree)
    else
-      local project_dir, rocks_tree = find_project_dir()
-      if project_dir then
-         path.use_tree(rocks_tree)
-      else
-         local trees = cfg.rocks_trees
-         path.use_tree(trees[#trees])
-      end
+      local trees = cfg.rocks_trees
+      path.use_tree(trees[#trees])
    end
 
    if type(cfg.root_dir) == "string" then

--- a/src/luarocks/command_line.lua
+++ b/src/luarocks/command_line.lua
@@ -143,15 +143,10 @@ function command_line.run_command(...)
    end
    
    if flags["project-tree"] then
-      table.insert(cfg.rocks_trees, 1, { name = "project", root = flags["project-tree"] } )
-   else
-      local project_dir, rocks_tree = find_project_dir()
-      if project_dir then
-         table.insert(cfg.rocks_trees, 1, { name = "project", root = rocks_tree } )
-      end
-   end
-
-   if flags["tree"] then
+      local tree = flags["project-tree"]
+      table.insert(cfg.rocks_trees, 1, { name = "project", root = tree } )
+      path.use_tree(tree)
+   elseif flags["tree"] then
       local named = false
       for _, tree in ipairs(cfg.rocks_trees) do
          if type(tree) == "table" and flags["tree"] == tree.name then
@@ -175,8 +170,14 @@ function command_line.run_command(...)
       end
       replace_tree(flags, cfg.home_tree)
    else
-      local trees = cfg.rocks_trees
-      path.use_tree(trees[#trees])
+      local project_dir, rocks_tree = find_project_dir()
+      if project_dir then
+         table.insert(cfg.rocks_trees, 1, { name = "project", root = rocks_tree } )
+         path.use_tree(rocks_tree)
+      else
+         local trees = cfg.rocks_trees
+         path.use_tree(trees[#trees])
+      end
    end
 
    if type(cfg.root_dir) == "string" then

--- a/src/luarocks/command_line.lua
+++ b/src/luarocks/command_line.lua
@@ -142,11 +142,7 @@ function command_line.run_command(...)
      cfg.branch = flags["branch"]
    end
    
-   if flags["project-tree"] then
-      local tree = flags["project-tree"]
-      table.insert(cfg.rocks_trees, 1, { name = "project", root = tree } )
-      path.use_tree(tree)
-   elseif flags["tree"] then
+   if flags["tree"] then
       local named = false
       for _, tree in ipairs(cfg.rocks_trees) do
          if type(tree) == "table" and flags["tree"] == tree.name then
@@ -162,6 +158,10 @@ function command_line.run_command(...)
          local root_dir = fs.absolute_name(flags["tree"])
          replace_tree(flags, root_dir)
       end
+   elseif flags["project-tree"] then
+      local tree = flags["project-tree"]
+      table.insert(cfg.rocks_trees, 1, { name = "project", root = tree } )
+      path.use_tree(tree)
    elseif flags["local"] then
       if not cfg.home_tree then
          die("The --local flag is meant for operating in a user's home directory.\n"..

--- a/src/luarocks/fs/win32.lua
+++ b/src/luarocks/fs/win32.lua
@@ -133,26 +133,50 @@ end
 -- @param version string: rock version to be used in loader context.
 -- @return boolean or (nil, string): True if succeeded, or nil and
 -- an error message.
-function win32.wrap_script(file, dest, name, version)
-   assert(type(file) == "string")
+function win32.wrap_script(file, dest, name, version, ...)
+   assert(type(file) == "string" or not file)
    assert(type(dest) == "string")
+   assert(type(name) == "string" or not name)
+   assert(type(version) == "string" or not version)
 
-   local base = dir.base_name(file)
-   local wrapname = fs.is_dir(dest) and dest.."/"..base or dest
+   local wrapname = fs.is_dir(dest) and dest.."/"..dir.base_name(file) or dest
    wrapname = wrapname..".bat"
-   local lpath, lcpath = cfg.package_paths()
-   lpath = util.cleanup_path(lpath, ";", cfg.lua_version)
-   lcpath = util.cleanup_path(lcpath, ";", cfg.lua_version)
    local wrapper = io.open(wrapname, "w")
    if not wrapper then
       return nil, "Could not open "..wrapname.." for writing."
    end
-   wrapper:write("@echo off\n")
-   local lua = dir.path(cfg.variables["LUA_BINDIR"], cfg.lua_interpreter)
-   local ppaths = "package.path="..util.LQ(lpath..";").."..package.path; package.cpath="..util.LQ(lcpath..";").."..package.cpath"
-   local addctx = "local k,l,_=pcall(require,"..util.LQ("luarocks.loader")..") _=k and l.add_context("..util.LQ(name)..","..util.LQ(version)..")"
-   wrapper:write(fs.Qb(lua)..' -e '..fs.Qb(ppaths)..' -e '..fs.Qb(addctx)..' '..fs.Qb(file)..' %*\n')
-   wrapper:write("exit /b %ERRORLEVEL%\n")
+
+   local lpath, lcpath = cfg.package_paths(cfg.root_dir)
+   lpath = util.cleanup_path(lpath, ";", cfg.lua_version)
+   lcpath = util.cleanup_path(lcpath, ";", cfg.lua_version)
+
+   local lpath_var, lcpath_var = util.lua_path_variables()
+
+   local addctx
+   if name and version then
+      addctx = "local k,l,_=pcall(require,'luarocks.loader') _=k " ..
+                     "and l.add_context('"..name.."','"..version.."')"
+   end
+
+   local argv = {
+      fs.Qb(dir.path(cfg.variables["LUA_BINDIR"], cfg.lua_interpreter)),
+      file and fs.Qb(file) or "",
+      ...
+   }
+
+   wrapper:write("@echo off\r\n")
+   if dest == "luarocks" then
+      wrapper:write("set "..fs.Qb(lpath_var.."="..package.path) .. "\r\n")
+      wrapper:write("set "..fs.Qb(lcpath_var.."="..package.cpath) .. "\r\n")
+   else
+      wrapper:write("set "..fs.Qb(lpath_var.."="..lpath..";%"..lpath_var.."%") .. "\r\n")
+      wrapper:write("set "..fs.Qb(lcpath_var.."="..lcpath..";%"..lcpath_var.."%") .. "\r\n")
+   end
+   if addctx then
+      wrapper:write("set "..fs.Qb("LUA_INIT=" .. addctx) .. "\r\n")
+   end
+   wrapper:write(table.concat(argv, " ") .. " %*\r\n")
+   wrapper:write("exit /b %ERRORLEVEL%\r\n")
    wrapper:close()
    return true
 end

--- a/src/luarocks/search.lua
+++ b/src/luarocks/search.lua
@@ -295,7 +295,7 @@ function search.print_result_tree(result_tree, porcelain)
             namespaces[key] = list
 
             repo.repo = dir.normalize(repo.repo)
-            table.insert(list, "   "..version.." ("..repo.arch..") - "..repo.repo)
+            table.insert(list, "   "..version.." ("..repo.arch..") - "..path.root_dir(repo.repo))
          end
       end
       for key, list in util.sortedpairs(namespaces) do

--- a/src/luarocks/util.lua
+++ b/src/luarocks/util.lua
@@ -129,6 +129,7 @@ local supported_flags = {
    ["output"] = "<file>",
    ["pack-binary-rock"] = true,
    ["porcelain"] = true,
+   ["project-tree"] = "<tree>",
    ["quick"] = true,
    ["rock-dir"] = true,
    ["rock-namespace"] = true,

--- a/src/luarocks/util.lua
+++ b/src/luarocks/util.lua
@@ -318,6 +318,23 @@ function util.lua_versions()
    end
 end
 
+function util.lua_path_variables()
+   local cfg = require("luarocks.core.cfg")
+   local lpath_var = "LUA_PATH"
+   local lcpath_var = "LUA_CPATH"
+
+   local lv = cfg.lua_version:gsub("%.", "_")
+   if lv ~= "5_1" then
+      if os.getenv("LUA_PATH_" .. lv) then
+         lpath_var = "LUA_PATH_" .. lv
+      end
+      if os.getenv("LUA_CPATH_" .. lv) then
+         lcpath_var = "LUA_CPATH_" .. lv
+      end
+   end
+   return lpath_var, lcpath_var
+end
+
 function util.starts_with(s, prefix)
    return s:sub(1,#prefix) == prefix
 end


### PR DESCRIPTION
This implements the plan outlined in "[Project: LuaRocks per-project workflow](https://github.com/luarocks/luarocks/wiki/Project:-LuaRocks-per-project-workflow)".

Given the [new distribution model](https://github.com/luarocks/luarocks/wiki/Project:-LuaRocks-new-distribution-model) is not here yet, it implements "Option 1" in the document linked above.

There are still some avenues for improvement:

* It does not yet process a config file stored inside `.luarocks`. The config file loading scheme is due to be changed with the [new distribution model](https://github.com/luarocks/luarocks/wiki/Project:-LuaRocks-new-distribution-model), so I thought it would be better do it all at once
* There is little configurability to how the project is initialized and the paths in use at this point. Some of it is deliberate, but it would be good to support some "project profiles" (e.g. appropriate settings for Löve2D projects)
* No tests for `luarocks init` yet! @georgeroman ? :)