### PR TITLE
Add a temporary path utility function to test_env

### DIFF
--- a/spec/fs_spec.lua
+++ b/spec/fs_spec.lua
@@ -6,17 +6,9 @@ local lfs = require("lfs")
 local is_win = test_env.TEST_TARGET_OS == "windows"
 local posix_ok = pcall(require, "posix")
 local testing_paths = test_env.testing_paths
+local get_tmp_path = test_env.get_tmp_path
 
 describe("Luarocks fs test #whitebox #w_fs", function()
-   local get_tmp_path = function()
-      local path = os.tmpname()
-      if is_win and not path:find(":") then
-         path = os.getenv("TEMP") .. path
-      end
-      os.remove(path)
-      return path
-   end
-
    local exists_file = function(path)
       local ok, err, code = os.rename(path, path)
       if not ok and code == 13 then

--- a/spec/util/test_env.lua
+++ b/spec/util/test_env.lua
@@ -88,6 +88,15 @@ function test_env.copy(source, destination)
    r_destination:close()
 end
 
+function test_env.get_tmp_path()
+   local path = os.tmpname()
+   if test_env.TEST_TARGET_OS == "windows" and not path:find(":") then
+      path = os.getenv("TEMP") .. path
+   end
+   os.remove(path)
+   return path
+end
+
 --- Helper function for execute_bool and execute_output
 -- @param command string: command to execute
 -- @param print_command boolean: print command if 'true'


### PR DESCRIPTION
This is going to be used a lot in the unit tests so I think it's worth adding it to test_env in order to be accessible anywhere in the tests.