### PR TITLE
Remove the empty file resulted when fs.download fails

### DIFF
--- a/src/luarocks/fs/tools.lua
+++ b/src/luarocks/fs/tools.lua
@@ -129,6 +129,7 @@ function tools.use_downloader(url, filename, cache)
    if ok then
       return true, filename
    else
+      os.remove(filename)
       return false
    end
 end


### PR DESCRIPTION
This commit removes the empty file resulted on the failure of fs.download (when it uses `wget` or `curl`)