### PR TITLE
Use $(CURDIR) instead of $(PWD) in Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ config-$(LUA_VERSION).lua.in: config.unix
 	rm -f src/luarocks/core/hardcoded.lua
 	echo "#!/bin/sh" > luarocks
 	echo "unset LUA_PATH LUA_PATH_5_2 LUA_PATH_5_3 LUA_PATH_5_4" >> luarocks
-	echo 'LUAROCKS_SYSCONFDIR="$(SYSCONFDIR)" LUA_PATH="$(PWD)/src/?.lua;;" exec "$(LUA_BINDIR)/$(LUA_INTERPRETER)" "$(PWD)/src/bin/luarocks" --project-tree="$(PWD)/lua_modules" "$$@"' >> luarocks
+	echo 'LUAROCKS_SYSCONFDIR="$(SYSCONFDIR)" LUA_PATH="$(CURDIR)/src/?.lua;;" exec "$(LUA_BINDIR)/$(LUA_INTERPRETER)" "$(CURDIR)/src/bin/luarocks" --project-tree="$(CURDIR)/lua_modules" "$$@"' >> luarocks
 	chmod +rx ./luarocks
 	./luarocks init
 	cp config-$(LUA_VERSION).lua.in .luarocks/config-$(LUA_VERSION).lua
@@ -29,7 +29,7 @@ luarocks-admin: config.unix
 	rm -f src/luarocks/core/hardcoded.lua
 	echo "#!/bin/sh" > luarocks-admin
 	echo "unset LUA_PATH LUA_PATH_5_2 LUA_PATH_5_3 LUA_PATH_5_4" >> luarocks-admin
-	echo 'LUAROCKS_SYSCONFDIR="$(SYSCONFDIR)" LUA_PATH="$(PWD)/src/?.lua;;" exec "$(LUA_BINDIR)/$(LUA_INTERPRETER)" "$(PWD)/src/bin/luarocks-admin" --project-tree="$(PWD)/lua_modules" "$$@"' >> luarocks-admin
+	echo 'LUAROCKS_SYSCONFDIR="$(SYSCONFDIR)" LUA_PATH="$(CURDIR)/src/?.lua;;" exec "$(LUA_BINDIR)/$(LUA_INTERPRETER)" "$(CURDIR)/src/bin/luarocks-admin" --project-tree="$(CURDIR)/lua_modules" "$$@"' >> luarocks-admin
 	chmod +rx ./luarocks-admin
 
 # ----------------------------------------
@@ -69,10 +69,10 @@ BINARY_TARGET=build-binary
 binary: $(BINARY_TARGET)/luarocks.exe $(BINARY_TARGET)/luarocks-admin.exe
 
 $(BINARY_TARGET)/luarocks.exe: ./luarocks
-	LUA_PATH="$(PWD)/src/?.lua;;" "$(LUA_BINDIR)/$(LUA_INTERPRETER)" binary/all_in_one "src/bin/luarocks" "$(LUA_DIR)" "^src/luarocks/admin/" "$(SYSCONFDIR)" $(BINARY_TARGET) $(BINARY_PLATFORM) $(BINARY_CC) $(BINARY_NM) $(BINARY_SYSROOT)
+	LUA_PATH="$(CURDIR)/src/?.lua;;" "$(LUA_BINDIR)/$(LUA_INTERPRETER)" binary/all_in_one "src/bin/luarocks" "$(LUA_DIR)" "^src/luarocks/admin/" "$(SYSCONFDIR)" $(BINARY_TARGET) $(BINARY_PLATFORM) $(BINARY_CC) $(BINARY_NM) $(BINARY_SYSROOT)
 
 $(BINARY_TARGET)/luarocks-admin.exe: ./luarocks
-	LUA_PATH="$(PWD)/src/?.lua;;" "$(LUA_BINDIR)/$(LUA_INTERPRETER)" binary/all_in_one "src/bin/luarocks-admin" "$(LUA_DIR)" "^src/luarocks/cmd/" "$(SYSCONFDIR)" $(BINARY_TARGET) $(BINARY_PLATFORM) $(BINARY_CC) $(BINARY_NM) $(BINARY_SYSROOT)
+	LUA_PATH="$(CURDIR)/src/?.lua;;" "$(LUA_BINDIR)/$(LUA_INTERPRETER)" binary/all_in_one "src/bin/luarocks-admin" "$(LUA_DIR)" "^src/luarocks/cmd/" "$(SYSCONFDIR)" $(BINARY_TARGET) $(BINARY_PLATFORM) $(BINARY_CC) $(BINARY_NM) $(BINARY_SYSROOT)
 
 # ----------------------------------------
 # Binary install

--- a/binary/Makefile.windows
+++ b/binary/Makefile.windows
@@ -15,7 +15,7 @@ windows-binary: windows-deps/lib/liblua.a windows-deps/lib/libssl.a windows-deps
 	STATIC_GCC_RANLIB=$(MINGW_PREFIX)-ranlib \
 	STATIC_GCC_CC=$(MINGW_PREFIX)-gcc \
 	LUAROCKS_CROSS_COMPILING=1 \
-	make binary LUA_DIR=$(PWD)/windows-deps BINARY_CC=$(MINGW_PREFIX)-gcc BINARY_NM=$(MINGW_PREFIX)-nm BINARY_PLATFORM=windows BINARY_TARGET=build-windows-binary BINARY_SYSROOT=$(MINGW_SYSROOT)
+	make binary LUA_DIR=$(CURDIR)/windows-deps BINARY_CC=$(MINGW_PREFIX)-gcc BINARY_NM=$(MINGW_PREFIX)-nm BINARY_PLATFORM=windows BINARY_TARGET=build-windows-binary BINARY_SYSROOT=$(MINGW_SYSROOT)
 
 build-windows-deps/lua-$(LIBLUA_VERSION).tar.gz:
 	mkdir -p build-windows-deps
@@ -35,7 +35,7 @@ build-windows-deps/openssl-$(OPENSSL_VERSION).tar.gz:
 build-windows-deps/openssl-$(OPENSSL_VERSION): build-windows-deps/openssl-$(OPENSSL_VERSION).tar.gz
 	cd build-windows-deps && tar zxvpf openssl-$(OPENSSL_VERSION).tar.gz
 windows-deps/lib/libssl.a: build-windows-deps/openssl-$(OPENSSL_VERSION)
-	cd build-windows-deps/openssl-$(OPENSSL_VERSION) && ./Configure --prefix=$(PWD)/windows-deps --cross-compile-prefix=$(MINGW_PREFIX)- $(OPENSSL_PLATFORM)
+	cd build-windows-deps/openssl-$(OPENSSL_VERSION) && ./Configure --prefix=$(CURDIR)/windows-deps --cross-compile-prefix=$(MINGW_PREFIX)- $(OPENSSL_PLATFORM)
 	cd build-windows-deps/openssl-$(OPENSSL_VERSION) && make
 	cd build-windows-deps/openssl-$(OPENSSL_VERSION) && make install_sw
 
@@ -46,7 +46,7 @@ build-windows-deps/zlib-$(ZLIB_VERSION): build-windows-deps/zlib-$(ZLIB_VERSION)
 	cd build-windows-deps && tar zxvpf zlib-$(ZLIB_VERSION).tar.gz
 windows-deps/lib/libz.a: build-windows-deps/zlib-$(ZLIB_VERSION)
 	cd build-windows-deps/zlib-$(ZLIB_VERSION) && sed -ie "s,dllwrap,$(MINGW_PREFIX)-dllwrap," win32/Makefile.gcc
-	cd build-windows-deps/zlib-$(ZLIB_VERSION) && ./configure --prefix=$(PWD)/windows-deps --static
+	cd build-windows-deps/zlib-$(ZLIB_VERSION) && ./configure --prefix=$(CURDIR)/windows-deps --static
 	cd build-windows-deps/zlib-$(ZLIB_VERSION) && make -f win32/Makefile.gcc CC=$(MINGW_PREFIX)-gcc AR=$(MINGW_PREFIX)-ar RC=$(MINGW_PREFIX)-windres STRIP=$(MINGW_PREFIX)-strip IMPLIB=libz.dll.a
 	mkdir -p windows-deps/include
 	cd build-windows-deps/zlib-$(ZLIB_VERSION) && cp zlib.h zconf.h ../../windows-deps/include


### PR DESCRIPTION
$(CURDIR) is built-in and is guaranteed to always work.
$(PWD) is inherited from the shell and may be incorrect or missing.
In particular, it is invalid if make is run by some program that
changes current directory prior to the execution.

(For example, using PWD breaks hererocks.)