### PR TITLE
 Do not rewrite path in util.cleanup_path if the desired version is a substring of the version

### DIFF
--- a/spec/util_spec.lua
+++ b/spec/util_spec.lua
@@ -155,4 +155,18 @@ describe("Luarocks util test #unit", function()
          assert.truthy(result:find("[\"e\"] = \"4\"", 1, true))
       end)
    end)
+      
+   describe("core.util.cleanup_path", function()
+     it("rewrites versions that do not match the provided version", function()
+        local expected = 'a/b/lua/5.3/?.lua;a/b/c/lua/5.3/?.lua'
+        local result = core_util.cleanup_path('a/b/lua/5.2/?.lua;a/b/c/lua/5.3/?.lua', ';', '5.3')
+        assert.are.equal(expected, result)
+     end)
+
+      it("does not rewrite versions for which the provided version is a substring", function()
+         local expected = 'a/b/lua/5.3/?.lua;a/b/c/lua/5.3.4/?.lua'
+         local result = core_util.cleanup_path('a/b/lua/5.2/?.lua;a/b/c/lua/5.3.4/?.lua', ';', '5.3')
+         assert.are.equal(expected, result)
+      end)
+   end)
 end)

--- a/src/luarocks/core/util.lua
+++ b/src/luarocks/core/util.lua
@@ -166,7 +166,11 @@ function util.cleanup_path(list, sep, lua_version)
    for _, part in ipairs(parts) do
       part = part:gsub("//", "/")
       if lua_version then
-         part = part:gsub("/lua/[%d.]+/", "/lua/"..lua_version.."/")
+         part = part:gsub("/lua/([%d.]+)/", function(part_version)
+            if part_version:sub(1, #lua_version) ~= lua_version then            
+               return "/lua/"..lua_version.."/"
+            end
+         end)
       end
       if not entries[part] then
          table.insert(final, part)


### PR DESCRIPTION
Closes #867 

This resolves the issue by checking whether the provided version is a substring of the matched version (anchored at the beginning of the string). This allows `/lua/5.3.5` to remain if the provided version is `'5.3'` while still filtering out `/lua/5.2` and `/lua/5.2.5`.