### PR TITLE
fix luajit detection on Buildroot

### DIFF
--- a/src/luarocks/deps.lua
+++ b/src/luarocks/deps.lua
@@ -506,15 +506,13 @@ function deps.check_lua(vars)
    end
    local shortv = cfg.lua_version:gsub("%.", "")
    local libnames = {
+      "luajit-" .. cfg.lua_version,
       "lua" .. cfg.lua_version,
       "lua" .. shortv,
       "lua-" .. cfg.lua_version,
       "lua-" .. shortv,
       "lua",
    }
-   if cfg.luajit_version then
-      table.insert(libnames, 1, "luajit-" .. cfg.lua_version)
-   end
    for _, libname in ipairs(libnames) do
       local ok = check_external_dependency("LUA", { library = libname }, vars, "build")
       if ok then


### PR DESCRIPTION
On Buildroot (cross compiled linux), when building a module for LuaJIT,
`luarocks` is runned by a host Lua 5.1,
and `LUA_LIBDIR` is a directory which contains only a target LuaJIT library.

see https://git.busybox.net/buildroot/commit/?id=bcccf228145bd8a2863279117810531bb7951ed0
and http://autobuild.buildroot.net/results/25c5e7ff5fab5ac45d959d50eded47bec4fa83b5/build-end.log