### PR TITLE
Use standardised umask invocation

### DIFF
--- a/src/luarocks/fs/unix.lua
+++ b/src/luarocks/fs/unix.lua
@@ -168,25 +168,24 @@ function unix.export_cmd(var, val)
    return ("export %s='%s'"):format(var, val)
 end
 
+local octal_to_rwx = {
+   ["0"] = "---",
+   ["1"] = "--x",
+   ["2"] = "-w-",
+   ["3"] = "-wx",
+   ["4"] = "r--",
+   ["5"] = "r-x",
+   ["6"] = "rw-",
+   ["7"] = "rwx",
+}
+local rwx_to_octal = {}
+for octal, rwx in pairs(octal_to_rwx) do
+   rwx_to_octal[rwx] = octal
+end
 --- Moderate the given permissions based on the local umask
 -- @param perms string: permissions to moderate
 -- @return string: the moderated permissions
 function unix._unix_moderate_permissions(perms)
-   local octal_to_rwx = {
-      ["0"] = "---",
-      ["1"] = "--x",
-      ["2"] = "-w-",
-      ["3"] = "-wx",
-      ["4"] = "r--",
-      ["5"] = "r-x",
-      ["6"] = "rw-",
-      ["7"] = "rwx",
-   }
-   local rwx_to_octal = {}
-   for octal, rwx in pairs(octal_to_rwx) do
-      rwx_to_octal[rwx] = octal
-   end
-
    local umask = fs._unix_umask()
 
    local moderated_perms = ""

--- a/src/luarocks/fs/unix/tools.lua
+++ b/src/luarocks/fs/unix/tools.lua
@@ -214,6 +214,9 @@ do
       local umask = assert(fd:read("*a"))
       fd:close()
       local u, g, o = umask:match("u=([rwx]*),g=([rwx]*),o=([rwx]*)")
+      if not u then
+         error("invalid umask result")
+      end
       umask_cache = string.format("%d%d%d",
          7 - rwx_to_octal(u),
          7 - rwx_to_octal(g),


### PR DESCRIPTION
Fixes #892 

Now the converts from symbolic to octal and back to symbolic again, but at least it should work on all systems.