### PR TITLE
show: base listing of modules on rock_manifest

### DIFF
--- a/src/luarocks/queries.lua
+++ b/src/luarocks/queries.lua
@@ -198,10 +198,11 @@ function query_mt:__tostring()
    if #self.constraints > 0 then
       local pretty = {}
       for _, c in ipairs(self.constraints) do
+         local v = c.version.string
          if c.op == "==" then
-            table.insert(pretty, tostring(c.version))
+            table.insert(pretty, v)
          else
-            table.insert(pretty, c.op .. " " .. tostring(c.version))
+            table.insert(pretty, c.op .. " " .. v)
          end
       end
       table.insert(out, " ")


### PR DESCRIPTION
List modules based on rock_manifest, for better precision. Overall management
of modules should be moved to use rock_manifest instead of the modules list
from the general local manifest, but this is a good first step.