### PR TITLE
write_rockspec: fix representation of Lua version dependency

### DIFF
--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -9,6 +9,11 @@ local lfs = require("lfs")
 test_env.unload_luarocks()
 
 describe("Luarocks init test #integration", function()
+
+   setup(function()
+      test_env.setup_specs()
+   end)
+
    it("LuaRocks init with no arguments", function()
       test_env.run_in_tmp(function(tmpdir)
          local myproject = tmpdir .. "/myproject"
@@ -42,6 +47,22 @@ describe("Luarocks init test #integration", function()
       end, finally)
    end)
    
+   it("LuaRocks init with --lua-versions", function()
+      test_env.run_in_tmp(function(tmpdir)
+         local myproject = tmpdir .. "/myproject"
+         lfs.mkdir(myproject)
+         lfs.chdir(myproject)
+
+         assert(run.luarocks("init --lua-versions=5.1,5.2,5.3"))
+         local rockspec_name = myproject .. "/myproject-dev-1.rockspec"
+         assert.truthy(lfs.attributes(rockspec_name))
+         local fd = assert(io.open(rockspec_name, "rb"))
+         local data = fd:read("*a")
+         fd:close()
+         assert.truthy(data:find("lua >= 5.1, < 5.4", 1, true))
+      end, finally)
+   end)
+
    it("LuaRocks init in a git repo", function()
       test_env.run_in_tmp(function(tmpdir)
          local myproject = tmpdir .. "/myproject"

--- a/src/luarocks/cmd/write_rockspec.lua
+++ b/src/luarocks/cmd/write_rockspec.lua
@@ -220,6 +220,13 @@ local function rockspec_cleanup(rockspec)
          rockspec[list] = nil
       end
    end
+   for _, list in ipairs({"dependencies", "build_dependencies", "test_dependencies"}) do
+      if rockspec[list] then
+         for i, entry in ipairs(rockspec[list]) do
+            rockspec[list][i] = tostring(entry)
+         end
+      end
+   end
 end
 
 function write_rockspec.command(flags, name, version, url_or_dir)


### PR DESCRIPTION
The Lua version dependency specified with --lua-versions was using the internal table format. This commit ensures that it is stored in rockspecs using the string format.

Includes a regression test.