### PR TITLE
Improve error messages when external tools are not found

### DIFF
--- a/src/luarocks/cmd/unpack.lua
+++ b/src/luarocks/cmd/unpack.lua
@@ -61,7 +61,7 @@ local function unpack_rock(rock_file, dir_name, kind)
 
    local ok, err, errcode = fetch.fetch_and_unpack_rock(rock_file, dir_name)
    if not ok then
-      return nil, "Failed unzipping rock "..rock_file, errcode
+      return nil, err, errcode
    end
    ok, err = fs.change_dir(dir_name)
    if not ok then return nil, err end

--- a/src/luarocks/fs/lua.lua
+++ b/src/luarocks/fs/lua.lua
@@ -111,7 +111,7 @@ function fs_lua.is_tool_available(tool_cmd, tool_name, arg)
    arg = arg or "--version"
    assert(type(arg) == "string")
 
-   if not fs.execute_quiet(fs.Q(tool_cmd), arg) then
+   if not fs.execute_quiet(tool_cmd, arg) then
       local msg = "'%s' program not found. Make sure %s is installed and is available in your PATH " ..
                   "(or you may want to edit the 'variables.%s' value in file '%s')"
       return nil, msg:format(tool_cmd, tool_name, tool_name:upper(), cfg.which_config().nearest)

--- a/src/luarocks/fs/tools.lua
+++ b/src/luarocks/fs/tools.lua
@@ -168,12 +168,14 @@ function tools.use_downloader(url, filename, cache)
         curl_cmd = curl_cmd .. "--connect-timeout "..tostring(cfg.connection_timeout).." "
       end
       ok = fs.execute_string(fs.quiet_stderr(curl_cmd..fs.Q(url).." > "..fs.Q(filename)))
+   else
+      return false, "No downloader tool available -- please install 'wget' or 'curl' in your system"
    end
    if ok then
       return true, filename
    else
       os.remove(filename)
-      return false
+      return false, "Failed downloading " .. url
    end
 end
 
@@ -189,9 +191,14 @@ function tools.get_md5(file)
       if computed then
          computed = computed:match("("..("%x"):rep(32)..")")
       end
-      if computed then return computed end
+      if computed then
+         return computed
+      else
+         return nil, "Failed to compute MD5 hash for file "..tostring(fs.absolute_name(file))
+      end
+   else
+      return false, "No MD5 checking tool available -- please install 'md5', 'md5sum' or 'openssl' in your system"
    end
-   return nil, "Failed to compute MD5 hash for file "..tostring(fs.absolute_name(file))
 end
 
 return tools

--- a/src/luarocks/fs/unix/tools.lua
+++ b/src/luarocks/fs/unix/tools.lua
@@ -125,6 +125,10 @@ end
 -- additional arguments.
 -- @return boolean: true on success, nil and error message on failure.
 function tools.zip(zipfile, ...)
+   local ok, err = fs.is_tool_available(vars.ZIP, "zip")
+   if not ok then
+      return nil, err
+   end
    if fs.execute_quiet(vars.ZIP.." -r", zipfile, ...) then
       return true
    else
@@ -137,6 +141,10 @@ end
 -- @return boolean: true on success, nil and error message on failure.
 function tools.unzip(zipfile)
    assert(zipfile)
+   local ok, err = fs.is_tool_available(vars.UNZIP, "unzip", "-h")
+   if not ok then
+      return nil, err
+   end
    if fs.execute_quiet(vars.UNZIP, zipfile) then
       return true
    else

--- a/src/luarocks/pack.lua
+++ b/src/luarocks/pack.lua
@@ -43,8 +43,9 @@ function pack.pack_source_rock(rockspec_file)
 
    fs.delete(rock_file)
    fs.copy(rockspec_file, source_dir, "read")
-   if not fs.zip(rock_file, dir.base_name(rockspec_file), dir.base_name(source_file)) then
-      return nil, "Failed packing "..rock_file
+   ok, err = fs.zip(rock_file, dir.base_name(rockspec_file), dir.base_name(source_file))
+   if not ok then
+      return nil, "Failed packing "..rock_file.." - "..err
    end
    fs.pop_dir()
 


### PR DESCRIPTION
Give informative error messages when external tools are not
installed. In particular, give a nicer error on `luarocks pack`
when 'zip' is not installed.

Closes #920 