### PR TITLE
Fix setting up deployment paths from a specified tree

### DIFF
--- a/src/luarocks/cmd.lua
+++ b/src/luarocks/cmd.lua
@@ -150,10 +150,10 @@ end
 
 local process_tree_flags
 do
-   local function replace_tree(flags, tree)
-      tree = dir.normalize(tree)
-      flags["tree"] = tree
-      path.use_tree(tree)
+   local function replace_tree(flags, root, tree)
+      root = dir.normalize(root)
+      flags["tree"] = root
+      path.use_tree(tree or root)
    end
 
    local function find_project_dir()
@@ -195,7 +195,7 @@ do
                if not tree.root then
                   return nil, "Configuration error: tree '"..tree.name.."' has no 'root' field."
                end
-               replace_tree(flags, tree.root)
+               replace_tree(flags, tree.root, tree)
                named = true
                break
             end


### PR DESCRIPTION
Fixes the problem when a tree to operate in is specified explicitly using the `--tree` flag, the deployment paths are set to default instead of those specified in the config.

**Reproducing**
With config
```lua
rocks_trees = {
    { name = [[system]],
         root    = [[D:\luarocks-test\luarocks\systree]],
         lua_dir = [[D:\luarocks-test\lib]],
    },
}
```
run `luarocks config --tree=system` and you'll see that variable `deploy_lua_dir` points to default path, although running luarocks without the `--tree=system` parameter the path is correct.