### PR TITLE
Fix granting permissions for all users on localized Windows

### DIFF
--- a/src/luarocks/fs/win32/tools.lua
+++ b/src/luarocks/fs/win32/tools.lua
@@ -278,7 +278,7 @@ function tools.set_permissions(filename, mode, scope)
 
       local ok
       -- Grant permissions available to all users
-      ok = fs.execute_quiet(fs.Q(vars.ICACLS) .. " " .. fs.Q(filename) .. " /inheritance:d /grant:r Everyone:" .. others_perms)
+      ok = fs.execute_quiet(fs.Q(vars.ICACLS) .. " " .. fs.Q(filename) .. " /inheritance:d /grant:r *S-1-1-0:" .. others_perms)
       if not ok then
          return false, "Failed setting permission " .. mode .. " for " .. scope
       end


### PR DESCRIPTION
On localized Windows systems granting permissions using `icacls` to `Everyone` is not correct.
Changing it to `*S-1-1-0` resolves the problem.
Details: https://support.microsoft.com/en-us/help/243330/well-known-security-identifiers-in-windows-operating-systems