### PR TITLE
Make environment variable changes local in Windows wrapper scripts

### DIFF
--- a/src/luarocks/fs/win32.lua
+++ b/src/luarocks/fs/win32.lua
@@ -161,6 +161,7 @@ function win32.wrap_script(script, target, deps_mode, name, version, ...)
    }
 
    wrapper:write("@echo off\r\n")
+   wrapper:write("setlocal\r\n")
    wrapper:write("set "..fs.Qb("LUAROCKS_SYSCONFDIR="..cfg.sysconfdir) .. "\r\n")
    if target == "luarocks" or target == "luarocks-admin" then
       wrapper:write("set "..fs.Qb(lpath_var.."="..package.path) .. "\r\n")


### PR DESCRIPTION
On Windows, the changes made by the wrapper script to the environment variables are global.
After the execution of a command installed with luarocks (i.e. busted) the variables in the parent environment are left modified.
I assume this is an unwanted effect, and this PR fix it.