### PR TITLE
Fix % expansion in windows wrapper.

### DIFF
--- a/src/luarocks/fs/win32.lua
+++ b/src/luarocks/fs/win32.lua
@@ -91,7 +91,7 @@ function win32.Qb(arg)
    arg = arg:gsub('\\(\\*)"', '\\%1%1"')
    arg = arg:gsub('\\+$', '%0%0')
    arg = arg:gsub('"', '\\"')
-   arg = arg:gsub('%%', '%%%%')
+   -- arg = arg:gsub('%%', '%%%%')
    return '"' .. arg .. '"'
 end
 


### PR DESCRIPTION
While writing the windows wrapper script expanding `%` into `%%`breaks variable expansions.
It should be `set LUA_PATH=....;%LUA_PATH%` while now it is `set LUA_PATH=....;%%LUA_PATH%%`
