### PR TITLE
Put quotes around platform tool paths

### DIFF
--- a/src/luarocks/fs/lua.lua
+++ b/src/luarocks/fs/lua.lua
@@ -111,7 +111,7 @@ function fs_lua.is_tool_available(tool_cmd, tool_name, arg)
    arg = arg or "--version"
    assert(type(arg) == "string")
 
-   if not fs.execute_quiet(tool_cmd, arg) then
+   if not fs.execute_quiet(fs.Q(tool_cmd), arg) then
       local msg = "'%s' program not found. Make sure %s is installed and is available in your PATH " ..
                   "(or you may want to edit the 'variables.%s' value in file '%s')"
       return nil, msg:format(tool_cmd, tool_name, tool_name:upper(), cfg.which_config().nearest)


### PR DESCRIPTION
A solution to #952 

This is completely untested, and I don't know enough about the codebase to know if it's the best solution - I just did this to get my installation working, and hope it can be of use to fixing this problem.

To elaborate -

On windows, luarocks finds the paths of the 'tools' at runtime, using a hardcoded path which is generated by `install.bat`, and it uses this to `os.execute` the tools.

However, if the path has a space in it (which it does by *default* in `Program Files (x86)`), then cmd fails to find the executable and the call fails. This means that the default installation of LuaRocks couldn't function on any windows machine