### PR TITLE
core.sysdetect: Fallback to /proc to detect Linux

### DIFF
--- a/src/luarocks/core/sysdetect.lua
+++ b/src/luarocks/core/sysdetect.lua
@@ -183,11 +183,11 @@ local function detect_elf_system(fd, hdr, sections)
 
       local procfile = io.open("/proc/sys/kernel/ostype")
       if procfile then
-	 local version = procfile:read(6)
-	 procfile:close()
-	 if version == "Linux\n" then
-	    return "linux"
-	 end
+         local version = procfile:read(6)
+         procfile:close()
+         if version == "Linux\n" then
+            return "linux"
+         end
       end
    end
    

--- a/src/luarocks/core/sysdetect.lua
+++ b/src/luarocks/core/sysdetect.lua
@@ -180,6 +180,15 @@ local function detect_elf_system(fd, hdr, sections)
             idx = idx + (vn_next * (vn_cnt + 1))
          end
       end
+
+      local procfile = io.open("/proc/sys/kernel/ostype")
+      if procfile then
+	 local version = procfile:read(6)
+	 procfile:close()
+	 if version == "Linux\n" then
+	    return "linux"
+	 end
+      end
    end
    
    return system


### PR DESCRIPTION
Check if `/proc/sys/kernel/ostype` reads as `"Linux\n"` to detect when a `"sysv"` platform is really Linux. This test is a fallback with lower priority than the existing heuristics based on ELF headers.

This fixes a problem with Alpine Linux docker images where LuaRocks does not detect Linux because `/bin/sh` ELF headers don't contain have the expected clues:

    $ docker run -ti alpine
    / # apk add --no-cache build-base
    [...]
    / # readelf -h /bin/sh
    ELF Header:
      Magic:   7f 45 4c 46 02 01 01 00 00 00 00 00 00 00 00 00
      Class:                             ELF64
      Data:                              2's complement, little endian
      Version:                           1 (current)
      OS/ABI:                            UNIX - System V
      ABI Version:                       0
      Type:                              DYN (Shared object file)
      Machine:                           Advanced Micro Devices X86-64
      Version:                           0x1
      Entry point address:               0xc410
      Start of program headers:          64 (bytes into file)
      Start of section headers:          803616 (bytes into file)
      Flags:                             0x0
      Size of this header:               64 (bytes)
      Size of program headers:           56 (bytes)
      Number of program headers:         7
      Size of section headers:           64 (bytes)
      Number of section headers:         22
      Section header string table index: 21