### PR TITLE
Add the --bin-suffix option

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -100,8 +100,8 @@ $(buildbinarydir)/luarocks-admin.exe: src/bin/luarocks-admin $(LUAROCKS_FILES)
 # Regular install
 # ----------------------------------------
 
-INSTALL_FILES = $(DESTDIR)$(bindir)/luarocks \
-	$(DESTDIR)$(bindir)/luarocks-admin \
+INSTALL_FILES = $(DESTDIR)$(bindir)/luarocks$(BINSUFFIX) \
+	$(DESTDIR)$(bindir)/luarocks-admin$(BINSUFFIX) \
 	$(DESTDIR)$(luarocksconfdir)/config-$(LUA_VERSION).lua \
 	$(patsubst src/%, $(DESTDIR)$(luadir)/%, $(LUAROCKS_FILES))
 
@@ -109,11 +109,11 @@ install: $(INSTALL_FILES)
 
 install-config: $(DESTDIR)$(luarocksconfdir)/config-$(LUA_VERSION).lua
 
-$(DESTDIR)$(bindir)/luarocks: $(builddir)/luarocks
+$(DESTDIR)$(bindir)/luarocks$(BINSUFFIX): $(builddir)/luarocks
 	mkdir -p "$(@D)"
 	$(INSTALL) "$<" "$@"
 
-$(DESTDIR)$(bindir)/luarocks-admin: $(builddir)/luarocks-admin
+$(DESTDIR)$(bindir)/luarocks-admin$(BINSUFFIX): $(builddir)/luarocks-admin
 	mkdir -p "$(@D)"
 	$(INSTALL) "$<" "$@"
 
@@ -138,8 +138,8 @@ INSTALL_BINARY_FILES = $(patsubst src/%, $(DESTDIR)$(luadir)/%, $(LUAROCKS_CORE_
 
 install-binary: $(INSTALL_BINARY_FILES)
 	mkdir -p "$(buildbinarydir)"
-	$(INSTALL) "$(buildbinarydir)/luarocks.exe" "$(DESTDIR)$(bindir)/luarocks"
-	$(INSTALL) "$(buildbinarydir)/luarocks-admin.exe" "$(DESTDIR)$(bindir)/luarocks-admin"
+	$(INSTALL) "$(buildbinarydir)/luarocks.exe" "$(DESTDIR)$(bindir)/luarocks$(BINSUFFIX)"
+	$(INSTALL) "$(buildbinarydir)/luarocks-admin.exe" "$(DESTDIR)$(bindir)/luarocks-admin$(BINSUFFIX)"
 
 # ----------------------------------------
 # Bootstrap install

--- a/configure
+++ b/configure
@@ -108,6 +108,11 @@ For better control, use the options below.
 Fine tuning of the installation directories:
   --sysconfdir=SYSCONFDIR      Directory for single-machine config [PREFIX/etc]
 
+Fine tuning of the installation binary:
+  --bin-suffix=SUFFIX          Suffix to append to luarocks and luarocks-admin
+                               binaries. e.g. --binsuffix=-5.1 will make
+                               luarocks-5.1 and luarocks-admin-5.1
+
 Where to install files provided by rocks:
   --rocks-tree=DIR             Root of the local tree of installed rocks.
                                To make files installed in this location
@@ -247,6 +252,12 @@ do
       [ -n "$value" ] || die "Missing value in flag $key."
       rocks_tree="$(canonicalpath "$value")"
       rocks_tree_SET=yes
+      ;;
+
+  # Customizing the luarocks binary
+  --bin-suffix)
+      [ -n "$value" ] || die "Missing value in flag $key."
+      BINSUFFIX="$value"
       ;;
 
    # Where is your Lua interpreter:
@@ -485,6 +496,7 @@ LUA_BINDIR=$LUA_BINDIR
 LUA_INCDIR=$LUA_INCDIR
 LUA_LIBDIR=$LUA_LIBDIR
 FORCE_CONFIG=$FORCE_CONFIG
+BINSUFFIX=$BINSUFFIX
 EOF
 
 echo


### PR DESCRIPTION
Allow setting a suffix for the luarocks and luarocks-admin binaries to
distinguish between different versions appropriately.