### PR TITLE
Patches to build via lenv

### DIFF
--- a/src/luarocks/core/dir.lua
+++ b/src/luarocks/core/dir.lua
@@ -15,7 +15,7 @@ local require = nil
 -- of the path.
 function dir.path(...)
    local t = {...}
-   while t[1] == "" do
+   while t[1] == "" or t[1] == nil do
       table.remove(t, 1)
    end
    return (table.concat(t, "/"):gsub("([^:])/+", "%1/"):gsub("^/+", "/"):gsub("/*$", ""))

--- a/src/luarocks/util.lua
+++ b/src/luarocks/util.lua
@@ -672,7 +672,7 @@ function util.lua_is_wrapper(interp)
    if not fd then
       return nil, err
    end
-   local data = fd:read(1000)
+   local data = fd:read(1000) or ''
    fd:close()
    return not not data:match("LUAROCKS_SYSCONFDIR")
 end


### PR DESCRIPTION
Version 3.1.0 fails to build when using [`lenv`](https://github.com/mah0x211/lenv). I've reproduced this on Linux (Ubuntu 18.04) and MacOS (Mojave). Version 3.0.4 and earlier install without issues.

I don't fully understand all of the problems, but one of the issues is that `lenv` uses a directory structure that seems to confuse LuaRocks when it is probing for `lua`/`luajit`. This is the top level directory structure inside of `~/.lenv`:

```
~/.lenv/
  bin/
  lua/ # note that this is a directory
  luajit_vers.txt
  rocks_vers.txt
  tmp/
  current/ # symlink to the current version
  luajit/ # note that this is a directory
  lua_vers.txt
  src/
```

The problem is when LuaRocks attempts to determine if Lua is a wrapper or not and fails to check whether the "binary" is actually a directory instead. Specifically, it trips up on directories like `~/.lenv/lua`.

The next issue (which I really don't understand, but I assume is related) is that LuaRocks errors out in `dir.path` when attempting to detect the Lua version because one of the path components is `nil`. I wasn't able to work backwards far enough to figure out exactly why this was happening, but I made it tolerant of `nil` being passed in.

I'm sure that these changes are not the optimal solutions so I'll happily accept any advice or alternative solutions.

If you want to reproduce the problem for yourself, install `lenv` following the instructions given [here](https://github.com/mah0x211/lenv#installation) and attempt to install any Lua:

```shell
curl -L http://git.io/lenv | perl
source ~/.lenvrc
lenv fetch
lenv install 5.3.5
```