### PR TITLE
fix: handle errors in lua wrapper check

### DIFF
--- a/src/luarocks/util.lua
+++ b/src/luarocks/util.lua
@@ -633,12 +633,16 @@ do
          for _, d in ipairs(bindirs) do
             for _, name in ipairs(names) do
                local lua_exe = d .. "/" .. name
-               table.insert(tried, lua_exe)
-               if not util.lua_is_wrapper(lua_exe) then
+               local is_wrapper, err = util.lua_is_wrapper(lua_exe)
+               if is_wrapper == false then
                   local lv, ljv = util.check_lua_version(lua_exe, luaver)
                   if lv then
                      return name, d, lv, ljv
                   end
+               elseif is_wrapper == true or err == nil then
+                  table.insert(tried, lua_exe)
+               else
+                  table.insert(tried, string.format("%-13s (%s)", lua_exe, err))
                end
             end
          end
@@ -672,8 +676,11 @@ function util.lua_is_wrapper(interp)
    if not fd then
       return nil, err
    end
-   local data = fd:read(1000)
+   local data, err = fd:read(1000)
    fd:close()
+   if not data then
+      return nil, err
+   end
    return not not data:match("LUAROCKS_SYSCONFDIR")
 end
 


### PR DESCRIPTION
A better (IMO) fix for #1003

Now errors are reported for each place searched, e.g.
```
$ mkdir lua
$ luarocks  --lua-dir .

Error: Lua interpreter not found at .
Tried:	./bin/lua5.4  (./bin/lua5.4: No such file or directory)
	./bin/lua54   (./bin/lua54: No such file or directory)
	./bin/lua-5.4 (./bin/lua-5.4: No such file or directory)
	./bin/lua-54  (./bin/lua-54: No such file or directory)
	./bin/lua5.3  (./bin/lua5.3: No such file or directory)
	./bin/lua53   (./bin/lua53: No such file or directory)
	./bin/lua-5.3 (./bin/lua-5.3: No such file or directory)
	./bin/lua-53  (./bin/lua-53: No such file or directory)
	./bin/lua5.2  (./bin/lua5.2: No such file or directory)
	./bin/lua52   (./bin/lua52: No such file or directory)
	./bin/lua-5.2 (./bin/lua-5.2: No such file or directory)
	./bin/lua-52  (./bin/lua-52: No such file or directory)
	./bin/lua5.1  (./bin/lua5.1: No such file or directory)
	./bin/lua51   (./bin/lua51: No such file or directory)
	./bin/lua-5.1 (./bin/lua-5.1: No such file or directory)
	./bin/lua-51  (./bin/lua-51: No such file or directory)
	./bin/luajit  (./bin/luajit: No such file or directory)
	./bin/lua     (./bin/lua: No such file or directory)
	./lua5.4      (./lua5.4: No such file or directory)
	./lua54       (./lua54: No such file or directory)
	./lua-5.4     (./lua-5.4: No such file or directory)
	./lua-54      (./lua-54: No such file or directory)
	./lua5.3      (./lua5.3: No such file or directory)
	./lua53       (./lua53: No such file or directory)
	./lua-5.3     (./lua-5.3: No such file or directory)
	./lua-53      (./lua-53: No such file or directory)
	./lua5.2      (./lua5.2: No such file or directory)
	./lua52       (./lua52: No such file or directory)
	./lua-5.2     (./lua-5.2: No such file or directory)
	./lua-52      (./lua-52: No such file or directory)
	./lua5.1      (./lua5.1: No such file or directory)
	./lua51       (./lua51: No such file or directory)
	./lua-5.1     (./lua-5.1: No such file or directory)
	./lua-51      (./lua-51: No such file or directory)
	./luajit      (./luajit: No such file or directory)
	./lua         (Is a directory)
```