### PR TITLE
avoid adding an empty entry to the RPATH

### DIFF
--- a/src/luarocks/build/builtin.lua
+++ b/src/luarocks/build/builtin.lua
@@ -243,7 +243,7 @@ function builtin.run(rockspec)
          local extras = { unpack(objects) }
          add_flags(extras, "-L%s", libdirs)
          if cfg.gcc_rpath then
-            add_flags(extras, "-Wl,-rpath,%s:", libdirs)
+            add_flags(extras, "-Wl,-rpath,%s", libdirs)
          end
          add_flags(extras, "-l%s", libraries)
          if cfg.link_lua_explicitly then


### PR DESCRIPTION
this avoids rpmbuild/check-rpaths erroring out like

`ERROR   0010: file '/...../mysql.so' contains an empty rpath in [/usr/lib64/mysql:]`

(because having an empty entry in rpath can be a security vulnerability)