### PR TITLE
[RFC] deps: fix handling of luajit

### DIFF
--- a/src/luarocks/deps.lua
+++ b/src/luarocks/deps.lua
@@ -545,7 +545,7 @@ function deps.check_lua(vars)
       "lua-" .. shortv,
       "lua",
    }
-   if cfg.lua_interpreter == "luajit" then
+   if cfg.luajit_version then
       table.insert(libnames, 1, "luajit-" .. cfg.lua_version)
    end
    local cache = {}

--- a/src/luarocks/deps.lua
+++ b/src/luarocks/deps.lua
@@ -545,7 +545,7 @@ function deps.check_lua(vars)
       "lua-" .. shortv,
       "lua",
    }
-   if cfg.luajit_version then
+   if cfg.lua_interpreter == "luajit" then
       table.insert(libnames, 1, "luajit-" .. cfg.lua_version)
    end
    local cache = {}


### PR DESCRIPTION
The installer will only write `lua_interpreter` into the config, but not
`luajit_version`.

But `deps.check_lua` would use `cfg.luajit_version` before this patch to
handle luajit, resulting in:

  - not finding headers in the first place, and if providing them
    (`--with-lua-include=…/include/luajit-2.0`)
  - not finding the library (which cannot be specified then, since only
    the dir can be passed)

This patch checks `cfg.lua_interpreter == "luajit"` instead.