### PR TITLE
detect LuaJIT dynamically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /lua
 /lua_modules
 /luarocks
+/.luarocks

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -47,13 +47,14 @@ $(builddir)/config-$(LUA_VERSION).lua: config.unix
 	> $@
 
 luarocks: config.unix $(builddir)/config-$(LUA_VERSION).lua
+	mkdir -p .luarocks
+	cp $(builddir)/config-$(LUA_VERSION).lua .luarocks/config-$(LUA_VERSION).lua
 	rm -f src/luarocks/core/hardcoded.lua
 	echo "#!/bin/sh" > luarocks
 	echo "unset LUA_PATH LUA_PATH_5_2 LUA_PATH_5_3 LUA_PATH_5_4 LUA_CPATH LUA_CPATH_5_2 LUA_CPATH_5_3 LUA_CPATH_5_4" >> luarocks
 	echo 'LUAROCKS_SYSCONFDIR="$(luarocksconfdir)" LUA_PATH="$(CURDIR)/src/?.lua;;" exec "$(LUA)" "$(CURDIR)/src/bin/luarocks" --project-tree="$(CURDIR)/lua_modules" "$$@"' >> luarocks
 	chmod +rx ./luarocks
 	./luarocks init
-	cp $(builddir)/config-$(LUA_VERSION).lua .luarocks/config-$(LUA_VERSION).lua
 
 luarocks-admin: config.unix
 	rm -f src/luarocks/core/hardcoded.lua

--- a/configure
+++ b/configure
@@ -445,7 +445,7 @@ check_incdir() {
    echo
    echo "If the development files for Lua (headers and libraries)"
    echo "are installed in your system, you may need to use the"
-   echo "$(BOLD --with-lua) or $(BOLD --with-include) flags to specify their location."
+   echo "$(BOLD --with-lua) or $(BOLD --with-lua-include) flags to specify their location."
    echo
    echo "If those files are not yet installed, you need to install"
    echo "them using the appropriate method for your operating system."

--- a/spec/build_spec.lua
+++ b/spec/build_spec.lua
@@ -507,7 +507,8 @@ describe("LuaRocks build tests #unit", function()
       runner.tick = true
       cfg.init()
       fs.init()
-      deps.check_lua(cfg.variables)
+      deps.check_lua_incdir(cfg.variables)
+      deps.check_lua_libdir(cfg.variables)
    end)
 
    teardown(function()

--- a/src/luarocks/build.lua
+++ b/src/luarocks/build.lua
@@ -109,9 +109,16 @@ local function process_dependencies(rockspec, opts)
       end
    end
 
-   local ok, err, errcode = deps.check_lua(rockspec.variables)
+   local ok, err, errcode = deps.check_lua_incdir(rockspec.variables)
    if not ok then
       return nil, err, errcode
+   end
+
+   if cfg.link_lua_explicitly then
+      local ok, err, errcode = deps.check_lua_libdir(rockspec.variables)
+      if not ok then
+         return nil, err, errcode
+      end
    end
 
    if opts.deps_mode == "none" then

--- a/src/luarocks/cmd.lua
+++ b/src/luarocks/cmd.lua
@@ -178,12 +178,12 @@ do
    do
       local function find_project_dir(project_tree)
          if project_tree then
-            return project_tree:gsub("[/\\][^/\\]+$", "")
+            return project_tree:gsub("[/\\][^/\\]+$", ""), true
          else
             local try = "."
             for _ = 1, 10 do -- FIXME detect when root dir was hit instead
                if util.exists(try .. "/.luarocks") and util.exists(try .. "/lua_modules") then
-                  return try
+                  return try, false
                elseif util.exists(try .. "/.luarocks-no-project") then
                   break
                end
@@ -265,8 +265,17 @@ do
       end
       
       detect_config_via_flags = function(flags)
-         local project_dir = find_project_dir(flags["project-tree"])
+         local project_dir, given = find_project_dir(flags["project-tree"])
          local detected = detect_lua_via_flags(flags, project_dir)
+         if flags["lua-version"] then
+            detected.given_lua_version = flags["lua-version"]
+         end
+         if flags["lua-dir"] then
+            detected.given_lua_dir = flags["lua-dir"]
+         end
+         if given then
+            detected.given_project_dir = project_dir
+         end
          detected.project_dir = project_dir
          return detected
       end

--- a/src/luarocks/cmd/config.lua
+++ b/src/luarocks/cmd/config.lua
@@ -234,7 +234,8 @@ end
 --- Driver function for "config" command.
 -- @return boolean: True if succeeded, nil on errors.
 function config_cmd.command(flags, var, val)
-   deps.check_lua(cfg.variables)
+   deps.check_lua_incdir(cfg.variables)
+   deps.check_lua_libdir(cfg.variables)
    
    -- deprecated flags
    if flags["lua-incdir"] then

--- a/src/luarocks/cmd/help.lua
+++ b/src/luarocks/cmd/help.lua
@@ -85,8 +85,9 @@ function help.command(description, commands, command)
       end
       print_section("CONFIGURATION")
       util.printout("\tLua version: " .. cfg.lua_version)
-      if cfg.luajit_version then
-         util.printout("\tLuaJIT version: " .. cfg.luajit_version)
+      local ljv = util.get_luajit_version()
+      if ljv then
+         util.printout("\tLuaJIT version: " .. ljv)
       end
       util.printout()
       util.printout("\tConfiguration files:")

--- a/src/luarocks/cmd/init.lua
+++ b/src/luarocks/cmd/init.lua
@@ -110,7 +110,6 @@ function init.command(flags, name, version)
    if config_tbl then
       local globals = {
          "lua_interpreter",
-         "luajit_version",
       }
       for _, v in ipairs(globals) do
          if cfg[v] then

--- a/src/luarocks/cmd/init.lua
+++ b/src/luarocks/cmd/init.lua
@@ -70,7 +70,7 @@ function init.command(flags, name, version)
    if not cfg.lua_found then
       return nil, "Lua installation is not found."
    end
-   local ok, err = deps.check_lua(cfg.variables)
+   local ok, err = deps.check_lua_incdir(cfg.variables)
    if not ok then
       return nil, err
    end

--- a/src/luarocks/cmd/show.lua
+++ b/src/luarocks/cmd/show.lua
@@ -116,8 +116,9 @@ end
 
 local function installed_rock_label(dep, tree)
    local installed, version
-   if cfg.rocks_provided[dep.name] then
-      installed, version = true, cfg.rocks_provided[dep.name]
+   local rocks_provided = util.get_rocks_provided()
+   if rocks_provided[dep.name] then
+      installed, version = true, rocks_provided[dep.name]
    else
       installed, version = search.pick_installed_rock(dep, tree)
    end

--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -356,6 +356,7 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
          lib = { "cyg?.dll", "?.dll", "lib?.dll" },
          include = { "?.h" }
       }
+      defaults.link_lua_explicitly = true
    end
 
    if platforms.unix then

--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -514,8 +514,6 @@ local cfg = {}
 -- environment. All fields below are optional:
 -- * lua_version (in x.y format, e.g. "5.3")
 -- * lua_bindir (e.g. "/usr/local/bin")
--- * lua_incdir (e.g. "/usr/local/include/lua5.3/")
--- * lua_libdir(e.g. "/usr/local/lib")
 -- * lua_dir (e.g. "/usr/local")
 -- * lua_interpreter (e.g. "lua-5.3")
 -- * project_dir (a string with the path of the project directory
@@ -533,8 +531,6 @@ function cfg.init(detected, warning)
    local lua_version = detected.lua_version or hardcoded.LUA_VERSION or _VERSION:sub(5)
    local lua_interpreter = detected.lua_interpreter or hardcoded.LUA_INTERPRETER or (arg and arg[-1] and arg[-1]:gsub(".*[\\/]", "")) or (is_windows and "lua.exe" or "lua")
    local lua_bindir = detected.lua_bindir or hardcoded.LUA_BINDIR or (arg and arg[-1] and arg[-1]:gsub("[\\/][^\\/]+$", ""))
-   local lua_incdir = detected.lua_incdir or hardcoded.LUA_INCDIR
-   local lua_libdir = detected.lua_libdir or hardcoded.LUA_LIBDIR
    local lua_dir = detected.lua_dir or hardcoded.LUA_DIR or (lua_bindir and lua_bindir:gsub("[\\/]bin$", ""))
    local project_dir = (not hardcoded.FORCE_CONFIG) and detected.project_dir
    
@@ -558,8 +554,8 @@ function cfg.init(detected, warning)
    cfg.variables = {
       LUA_DIR = lua_dir,
       LUA_BINDIR = lua_bindir,
-      LUA_INCDIR = lua_incdir,
-      LUA_LIBDIR = lua_libdir,
+      LUA_LIBDIR = hardcoded.LUA_LIBDIR,
+      LUA_INCDIR = hardcoded.LUA_INCDIR,
    }
 
    cfg.init = init
@@ -668,14 +664,14 @@ function cfg.init(detected, warning)
    -- Let's finish up the cfg table.
    ----------------------------------------
 
-   -- Settings detected or given via the CLI (i.e. --lua-dir) take precedence over config files:
-   cfg.project_dir = project_dir
-   cfg.lua_version = detected.lua_version or cfg.lua_version
+   -- Settings given via the CLI (i.e. --lua-dir) take precedence over config files.
+   cfg.project_dir = detected.given_project_dir or project_dir
+   cfg.lua_version = detected.given_lua_version or lua_version or cfg.lua_version
+   cfg.variables.LUA_DIR = detected.given_lua_dir or cfg.variables.LUA_DIR or lua_dir
+
    cfg.lua_interpreter = detected.lua_interpreter or cfg.lua_interpreter
-   cfg.variables.LUA_BINDIR = detected.lua_bindir or cfg.variables.LUA_BINDIR or lua_bindir
-   cfg.variables.LUA_INCDIR = detected.lua_incdir or cfg.variables.LUA_INCDIR or lua_incdir
-   cfg.variables.LUA_LIBDIR = detected.lua_libdir or cfg.variables.LUA_LIBDIR or lua_libdir
-   cfg.variables.LUA_DIR = detected.lua_dir or cfg.variables.LUA_DIR or lua_dir
+
+   cfg.variables.LUA_BINDIR = cfg.variables.LUA_BINDIR or lua_bindir
 
    -- Build a default list of rocks trees if not given
    if cfg.rocks_trees == nil then

--- a/src/luarocks/core/util.lua
+++ b/src/luarocks/core/util.lua
@@ -120,13 +120,14 @@ function util.show_table(t, tname, top_indent)
    return cart .. autoref
 end
 
---- Merges contents of src on top of dst's contents.
+--- Merges contents of src on top of dst's contents
+-- (i.e. if an key from src already exists in dst, replace it).
 -- @param dst Destination table, which will receive src's contents.
 -- @param src Table which provides new contents to dst.
 function util.deep_merge(dst, src)
    for k, v in pairs(src) do
       if type(v) == "table" then
-         if not dst[k] then
+         if dst[k] == nil then
             dst[k] = {}
          end
          if type(dst[k]) == "table" then
@@ -140,13 +141,14 @@ function util.deep_merge(dst, src)
    end
 end
 
---- Merges contents of src below those of dst's contents.
+--- Merges contents of src below those of dst's contents
+-- (i.e. if an key from src already exists in dst, do not replace it).
 -- @param dst Destination table, which will receive src's contents.
 -- @param src Table which provides new contents to dst.
 function util.deep_merge_under(dst, src)
    for k, v in pairs(src) do
       if type(v) == "table" then
-         if not dst[k] then
+         if dst[k] == nil then
             dst[k] = {}
          end
          if type(dst[k]) == "table" then

--- a/src/luarocks/deps.lua
+++ b/src/luarocks/deps.lua
@@ -497,7 +497,7 @@ function deps.scan_deps(results, manifest, name, version, deps_mode)
       rocks_provided = rockspec.rocks_provided
       mdn[version] = dependencies
    else
-      rocks_provided = setmetatable({}, { __index = cfg.rocks_provided_3_0 })
+      rocks_provided = util.get_rocks_provided()
    end
    local matched = deps.match_deps(dependencies, rocks_provided, nil, deps_mode)
    results[name] = version
@@ -533,8 +533,9 @@ end
 
 function deps.check_lua(vars)
    local incdir_found = true
+   local ljv = util.get_luajit_version()
    if (not vars.LUA_INCDIR) and vars.LUA_DIR then
-      vars.LUA_INCDIR = find_lua_incdir(vars.LUA_DIR, cfg.lua_version, cfg.luajit_version)
+      vars.LUA_INCDIR = find_lua_incdir(vars.LUA_DIR, cfg.lua_version, ljv)
       incdir_found = (vars.LUA_INCDIR ~= nil)
    end
    local shortv = cfg.lua_version:gsub("%.", "")
@@ -545,7 +546,7 @@ function deps.check_lua(vars)
       "lua-" .. shortv,
       "lua",
    }
-   if cfg.luajit_version then
+   if ljv then
       table.insert(libnames, 1, "luajit-" .. cfg.lua_version)
    end
    local cache = {}

--- a/src/luarocks/deps.lua
+++ b/src/luarocks/deps.lua
@@ -531,7 +531,7 @@ local function find_lua_incdir(prefix, luaver, luajitver)
    return nil
 end
 
-function deps.check_lua(vars)
+function deps.check_lua_incdir(vars)
    local ljv = util.get_luajit_version()
 
    if (not vars.LUA_INCDIR) and vars.LUA_DIR then
@@ -541,30 +541,32 @@ function deps.check_lua(vars)
       end
    end
 
-   if cfg.link_lua_explicitly then
-      local shortv = cfg.lua_version:gsub("%.", "")
-      local libnames = {
-         "lua" .. cfg.lua_version,
-         "lua" .. shortv,
-         "lua-" .. cfg.lua_version,
-         "lua-" .. shortv,
-         "lua",
-      }
-      if ljv then
-         table.insert(libnames, 1, "luajit-" .. cfg.lua_version)
-      end
-      local cache = {}
-      for _, libname in ipairs(libnames) do
-         local ok = check_external_dependency("LUA", { library = libname }, vars, "build", cache)
-         if ok then
-            vars.LUALIB = vars.LUA_LIBDIR_FILE
-            return true
-         end
-      end
-      return nil, "Failed finding Lua library. You may need to configure LUA_LIBDIR.", "dependency"
-   end
-   
    return true
+end
+
+function deps.check_lua_libdir(vars)
+   local ljv = util.get_luajit_version()
+
+   local shortv = cfg.lua_version:gsub("%.", "")
+   local libnames = {
+      "lua" .. cfg.lua_version,
+      "lua" .. shortv,
+      "lua-" .. cfg.lua_version,
+      "lua-" .. shortv,
+      "lua",
+   }
+   if ljv then
+      table.insert(libnames, 1, "luajit-" .. cfg.lua_version)
+   end
+   local cache = {}
+   for _, libname in ipairs(libnames) do
+      local ok = check_external_dependency("LUA", { library = libname }, vars, "build", cache)
+      if ok then
+         vars.LUALIB = vars.LUA_LIBDIR_FILE
+         return true
+      end
+   end
+   return nil, "Failed finding Lua library. You may need to configure LUA_LIBDIR.", "dependency"
 end
 
 local valid_deps_modes = {

--- a/src/luarocks/manif/writer.lua
+++ b/src/luarocks/manif/writer.lua
@@ -453,7 +453,7 @@ function writer.check_dependencies(repo, deps_mode)
          for _, entry in ipairs(version_entries) do
             if entry.arch == "installed" then
                if manifest.dependencies[name] and manifest.dependencies[name][version] then
-                  deps.report_missing_dependencies(name, version, manifest.dependencies[name][version], deps_mode, cfg.rocks_provided_3_0)
+                  deps.report_missing_dependencies(name, version, manifest.dependencies[name][version], deps_mode, util.get_rocks_provided())
                end
             end
          end

--- a/src/luarocks/rockspecs.lua
+++ b/src/luarocks/rockspecs.lua
@@ -5,7 +5,7 @@ local dir = require("luarocks.dir")
 local path = require("luarocks.path")
 local queries = require("luarocks.queries")
 local type_rockspec = require("luarocks.type.rockspec")
-local util = require("luarocks.core.util")
+local util = require("luarocks.util")
 local vers = require("luarocks.core.vers")
 
 local rockspec_mt = {}
@@ -142,9 +142,7 @@ function rockspecs.from_persisted_table(filename, rockspec, globals, quick)
                                 or  ".") )
                       or base
 
-   rockspec.rocks_provided = (rockspec:format_is_at_least("3.0")
-                              and cfg.rocks_provided_3_0
-                              or  cfg.rocks_provided)
+   rockspec.rocks_provided = util.get_rocks_provided(rockspec)
 
    for _, key in ipairs({"dependencies", "build_dependencies", "test_dependencies"}) do
       local ok, err = convert_dependencies(rockspec, key)

--- a/src/luarocks/search.lua
+++ b/src/luarocks/search.lua
@@ -164,9 +164,9 @@ function search.search_repos(query, lua_version)
          end
       end
    end
-   -- search through rocks in cfg.rocks_provided
+   -- search through rocks in rocks_provided
    local provided_repo = "provided by VM or rocks_provided"
-   for name, version in pairs(cfg.rocks_provided) do
+   for name, version in pairs(util.get_rocks_provided()) do
       local result = results.new(name, version, provided_repo, "installed")
       store_if_match(result_tree, result, query)
    end
@@ -242,9 +242,11 @@ end
 function search.find_suitable_rock(query, cli)
    assert(query:type() == "query")
 
-   if cfg.rocks_provided[query.name] ~= nil then
-      -- Do not install versions listed in cfg.rocks_provided.
-      return nil, "Rock "..query.name.." "..cfg.rocks_provided[query.name]..
+   local rocks_provided = util.get_rocks_provided()
+   
+   if rocks_provided[query.name] ~= nil then
+      -- Do not install versions listed in rocks_provided.
+      return nil, "Rock "..query.name.." "..rocks_provided[query.name]..
          " is already provided by VM or via 'rocks_provided' in the config file."
    end
    


### PR DESCRIPTION
This reduces the complexity of the interaction between build-time configuration, run-time auto-detection, and CLI flag overrides (which, all together, make for a pretty confusing support matrix). The LuaJIT version is now always auto-detected at run-time based on the Lua interpreter currently configured, based on the values of configuration options `variables.LUA_BINDIR` and `lua_interpreter`.

This is proposed as an alternative to #1043, #1042, #883. 

@blueyed @fperrad Please let me know if this approach works for you!