### PR TITLE
path: keep order of existing entries in PATH

### DIFF
--- a/spec/util_spec.lua
+++ b/spec/util_spec.lua
@@ -157,16 +157,34 @@ describe("Luarocks util test #unit", function()
    end)
       
    describe("core.util.cleanup_path", function()
+     it("does not change order of existing items of prepended path", function()
+        local sys_path = '/usr/local/bin;/usr/bin'
+        local lr_path = '/home/user/.luarocks/bin;/usr/bin'
+        local path = lr_path .. ';' .. sys_path
+
+        local result = core_util.cleanup_path(path, ';', '5.3', false)
+        assert.are.equal('/home/user/.luarocks/bin;/usr/local/bin;/usr/bin', result)
+     end)
+
+     it("does not change order of existing items of appended path", function()
+        local sys_path = '/usr/local/bin;/usr/bin'
+        local lr_path = '/home/user/.luarocks/bin;/usr/bin'
+        local path = sys_path .. ';' .. lr_path
+
+        local result = core_util.cleanup_path(path, ';', '5.3', true)
+        assert.are.equal('/usr/local/bin;/usr/bin;/home/user/.luarocks/bin', result)
+     end)
+
      it("rewrites versions that do not match the provided version", function()
         local expected = 'a/b/lua/5.3/?.lua;a/b/c/lua/5.3/?.lua'
         local result = core_util.cleanup_path('a/b/lua/5.2/?.lua;a/b/c/lua/5.3/?.lua', ';', '5.3')
         assert.are.equal(expected, result)
      end)
 
-      it("does not rewrite versions for which the provided version is a substring", function()
-         local expected = 'a/b/lua/5.3/?.lua;a/b/c/lua/5.3.4/?.lua'
-         local result = core_util.cleanup_path('a/b/lua/5.2/?.lua;a/b/c/lua/5.3.4/?.lua', ';', '5.3')
-         assert.are.equal(expected, result)
-      end)
+     it("does not rewrite versions for which the provided version is a substring", function()
+        local expected = 'a/b/lua/5.3/?.lua;a/b/c/lua/5.3.4/?.lua'
+        local result = core_util.cleanup_path('a/b/lua/5.2/?.lua;a/b/c/lua/5.3.4/?.lua', ';', '5.3')
+        assert.are.equal(expected, result)
+     end)
    end)
 end)

--- a/src/luarocks/cmd/path.lua
+++ b/src/luarocks/cmd/path.lua
@@ -60,10 +60,10 @@ function path_cmd.command(flags)
    
    local lpath_var, lcpath_var = util.lua_path_variables()
 
-   util.printout(fs.export_cmd(lpath_var, util.cleanup_path(lr_path, ';', cfg.lua_version)))
-   util.printout(fs.export_cmd(lcpath_var, util.cleanup_path(lr_cpath, ';', cfg.lua_version)))
+   util.printout(fs.export_cmd(lpath_var, util.cleanup_path(lr_path, ';', cfg.lua_version, flags["append"])))
+   util.printout(fs.export_cmd(lcpath_var, util.cleanup_path(lr_cpath, ';', cfg.lua_version, flags["append"])))
    if not flags["no-bin"] then
-      util.printout(fs.export_cmd("PATH", util.cleanup_path(lr_bin, path_sep)))
+      util.printout(fs.export_cmd("PATH", util.cleanup_path(lr_bin, path_sep, nil, flags["append"])))
    end
    return true
 end


### PR DESCRIPTION
Implements suggestion by @FSMaxB:

> Add an additional flag to util.cleanup_path that specifies if the cleanup
> happens from the right or from the left. If append is true, clean up from the
> left, otherwise clean up from the right.

Fixes #763. Thanks @blueyed for the nudge!