### PR TITLE
Fix fs.is_dir detection on the Mac, take 2

### DIFF
--- a/src/luarocks/fs/unix.lua
+++ b/src/luarocks/fs/unix.lua
@@ -220,8 +220,11 @@ function unix.is_dir(file)
       return true
    end
    if fd then
+      local _, _, ecode = fd:read(1)
       fd:close()
-      return true
+      if ecode == 21 then -- "Is a directory"
+         return true
+      end
    end
    return false
 end


### PR DESCRIPTION
We tried to fix this in 43b7c42ae09526a7c5e91edf796d27aa2c564f00 but apparently the fix was not complete. Thanks to @andyli for the report and pointer to the failing CI
build.

Fixes #104