### PR TITLE
fs: use Unix fork-free versions of is_file/is_dir in Linux and macOS only

### DIFF
--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -806,12 +806,21 @@ function cfg.init(detected, warning)
       return platforms[name]
    end
 
-   function cfg.each_platform()
-      local i = 0
+   -- @param direction (optional) "least-specific-first" (default) or "most-specific-first"
+   function cfg.each_platform(direction)
+      direction = direction or "least-specific-first"
+      local i, delta
+      if direction == "least-specific-first" then
+         i = 0
+         delta = 1
+      else
+         i = #platform_order + 1
+         delta = -1
+      end
       return function()
          local p
          repeat
-            i = i + 1
+            i = i + delta
             p = platform_order[i]
          until (not p) or platforms[p]
          return p

--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -370,6 +370,7 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
       defaults.variables.LD = "gcc"
       defaults.gcc_rpath = true
       defaults.variables.LIBFLAG = "-shared"
+      defaults.variables.TEST = "test"
 
       defaults.external_deps_patterns = {
          bin = { "?" },

--- a/src/luarocks/fs/linux.lua
+++ b/src/luarocks/fs/linux.lua
@@ -1,0 +1,50 @@
+--- Linux-specific implementation of filesystem and platform abstractions.
+local linux = {}
+
+local fs = require("luarocks.fs")
+local dir = require("luarocks.dir")
+
+function linux.is_dir(file)
+   file = fs.absolute_name(file)
+   file = dir.normalize(file) .. "/."
+   local fd, _, code = io.open(file, "r")
+   if code == 2 then -- "No such file or directory"
+      return false
+   end
+   if code == 20 then -- "Not a directory", regardless of permissions
+      return false
+   end
+   if code == 13 then -- "Permission denied", but is a directory
+      return true
+   end
+   if fd then
+      local _, _, ecode = fd:read(1)
+      fd:close()
+      if ecode == 21 then -- "Is a directory"
+         return true
+      end
+   end
+   return false
+end
+
+function linux.is_file(file)
+   file = fs.absolute_name(file)
+   if fs.is_dir(file) then
+      return false
+   end
+   file = dir.normalize(file)
+   local fd, _, code = io.open(file, "r")
+   if code == 2 then -- "No such file or directory"
+      return false
+   end
+   if code == 13 then -- "Permission denied", but it exists
+      return true
+   end
+   if fd then
+      fd:close()
+      return true
+   end
+   return false
+end
+
+return linux

--- a/src/luarocks/fs/macosx.lua
+++ b/src/luarocks/fs/macosx.lua
@@ -1,0 +1,50 @@
+--- macOS-specific implementation of filesystem and platform abstractions.
+local macosx = {}
+
+local fs = require("luarocks.fs")
+local dir = require("luarocks.dir")
+
+function macosx.is_dir(file)
+   file = fs.absolute_name(file)
+   file = dir.normalize(file) .. "/."
+   local fd, _, code = io.open(file, "r")
+   if code == 2 then -- "No such file or directory"
+      return false
+   end
+   if code == 20 then -- "Not a directory", regardless of permissions
+      return false
+   end
+   if code == 13 then -- "Permission denied", but is a directory
+      return true
+   end
+   if fd then
+      local _, _, ecode = fd:read(1)
+      fd:close()
+      if ecode == 21 then -- "Is a directory"
+         return true
+      end
+   end
+   return false
+end
+
+function macosx.is_file(file)
+   file = fs.absolute_name(file)
+   if fs.is_dir(file) then
+      return false
+   end
+   file = dir.normalize(file)
+   local fd, _, code = io.open(file, "r")
+   if code == 2 then -- "No such file or directory"
+      return false
+   end
+   if code == 13 then -- "Permission denied", but it exists
+      return true
+   end
+   if fd then
+      fd:close()
+      return true
+   end
+   return false
+end
+
+return macosx

--- a/src/luarocks/fs/unix.lua
+++ b/src/luarocks/fs/unix.lua
@@ -206,49 +206,6 @@ function unix._unix_moderate_permissions(perms)
    return moderated_perms
 end
 
-function unix.is_dir(file)
-   file = fs.absolute_name(file)
-   file = dir.normalize(file) .. "/."
-   local fd, _, code = io.open(file, "r")
-   if code == 2 then -- "No such file or directory"
-      return false
-   end
-   if code == 20 then -- "Not a directory", regardless of permissions
-      return false
-   end
-   if code == 13 then -- "Permission denied", but is a directory
-      return true
-   end
-   if fd then
-      local _, _, ecode = fd:read(1)
-      fd:close()
-      if ecode == 21 then -- "Is a directory"
-         return true
-      end
-   end
-   return false
-end
-
-function unix.is_file(file)
-   file = fs.absolute_name(file)
-   if fs.is_dir(file) then
-      return false
-   end
-   file = dir.normalize(file)
-   local fd, _, code = io.open(file, "r")
-   if code == 2 then -- "No such file or directory"
-      return false
-   end
-   if code == 13 then -- "Permission denied", but it exists
-      return true
-   end
-   if fd then
-      fd:close()
-      return true
-   end
-   return false
-end
-
 function unix.system_cache_dir()
    if fs.is_dir("/var/cache") then
       return "/var/cache"

--- a/src/luarocks/fs/unix/tools.lua
+++ b/src/luarocks/fs/unix/tools.lua
@@ -273,4 +273,28 @@ function tools.make_temp_dir(name_pattern)
    return nil, "Failed to create temporary directory "..tostring(dirname)
 end
 
+--- Test is file/directory exists
+-- @param file string: filename to test
+-- @return boolean: true if file exists, false otherwise.
+function tools.exists(file)
+   assert(file)
+   return fs.execute(vars.TEST, "-e", file)
+end
+
+--- Test is pathname is a directory.
+-- @param file string: pathname to test
+-- @return boolean: true if it is a directory, false otherwise.
+function tools.is_dir(file)
+   assert(file)
+   return fs.execute(vars.TEST, "-d", file)
+end
+
+--- Test is pathname is a regular file.
+-- @param file string: pathname to test
+-- @return boolean: true if it is a regular file, false otherwise.
+function tools.is_file(file)
+   assert(file)
+   return fs.execute(vars.TEST, "-f", file)
+end
+
 return tools


### PR DESCRIPTION
The Unix fork-free version relies on non-standard behaviors. It works on Linux, but it took a while for it to work properly in macOS, and it turns out that you can't really properly detect a directory in FreeBSD using io.open() because it can actually open a directory. To avoid filling in platform-specific tricks in luarocks/fs/unix.lua, which was never the goal, it's better to move the fork-free operations to Linux and macOS specific backends, and keep other Unices using the 'test' command.