### PR TITLE
Fix wrong versions in search failure error message

### DIFF
--- a/src/luarocks/manif.lua
+++ b/src/luarocks/manif.lua
@@ -91,9 +91,11 @@ end
 -- through this function.
 -- @param repo_url string: URL or pathname for the repository.
 -- @param lua_version string: Lua version in "5.x" format, defaults to installed version.
+-- @param versioned_only boolean: If true, do not fall back to the main manifest
+-- if a versioned manifest was not found.
 -- @return table or (nil, string, [string]): A table representing the manifest,
 -- or nil followed by an error message and an optional error code.
-function manif.load_manifest(repo_url, lua_version)
+function manif.load_manifest(repo_url, lua_version, versioned_only)
    assert(type(repo_url) == "string")
    assert(type(lua_version) == "string" or not lua_version)
    lua_version = lua_version or cfg.lua_version
@@ -107,7 +109,7 @@ function manif.load_manifest(repo_url, lua_version)
    local filenames = {
       "manifest-"..lua_version..".zip",
       "manifest-"..lua_version,
-      "manifest",
+      not versioned_only and "manifest" or nil,
    }
 
    local protocol, repodir = dir.split_url(repo_url)

--- a/src/luarocks/search.lua
+++ b/src/luarocks/search.lua
@@ -108,7 +108,7 @@ local function manifest_search(result_tree, repo, query, lua_version, is_local)
       repo = repo .. "/manifests/" .. query.namespace
    end
 
-   local manifest, err, errcode = manif.load_manifest(repo, lua_version)
+   local manifest, err, errcode = manif.load_manifest(repo, lua_version, true)
    if not manifest then
       return nil, err, errcode
    end


### PR DESCRIPTION
Fixes #973.

Source of the bug: luarocks.org does not have a manifest at https://luarocks.org/manifest-5.4 so `manif.load_manifest` falls back to https://luarocks.org/manifest. So when `search.search_repos` is called for Lua 5.4, it finds a match in the main manifest.

Output for `luarocks --lua-version 5.3 install lapis`:
```
lapis not found for Lua 5.3.
Checking if available for other Lua versions...
Checking for Lua 5.1...
Checking for Lua 5.2...
Checking for Lua 5.4...
Warning: Failed searching manifest: Failed fetching manifest for https://luarocks.org - Failed downloading https://luarocks.org/manifest-5.4 - /home/paul/.cache/luarocks/https___luarocks.org/manifest-5.4
Warning: Failed searching manifest: Failed fetching manifest for https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/ - Failed downloading https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/manifest-5.4 - /home/paul/.cache/luarocks/https___raw.githubusercontent.com_rocks-moonscript-org_moonrocks-mirror_master_/manifest-5.4
Warning: Failed searching manifest: Failed fetching manifest for http://luafr.org/moonrocks/ - Failed downloading http://luafr.org/moonrocks/manifest-5.4 - /home/paul/.cache/luarocks/http___luafr.org_moonrocks_/manifest-5.4
Warning: Failed searching manifest: Failed fetching manifest for http://luarocks.logiceditor.com/rocks - Failed downloading http://luarocks.logiceditor.com/rocks/manifest-5.4 - /home/paul/.cache/luarocks/http___luarocks.logiceditor.com_rocks/manifest-5.4

Error: lapis supports only Lua 5.1 but not Lua 5.3.
(To suppress these checks run 'luarocks --lua-version=5.3 config version_check_on_fail false')
```
The warnings are ugly but I'm not sure what to do about them.