### PR TITLE
support RaptorJIT

### DIFF
--- a/src/luarocks/util.lua
+++ b/src/luarocks/util.lua
@@ -600,7 +600,7 @@ do
 
       local ljv
       if cfg.lua_version == "5.1" then
-         ljv = util.popen_read(Q(cfg.variables["LUA_BINDIR"] .. "/" .. cfg.lua_interpreter) .. ' -e "io.write(tostring(jit and jit.version:sub(8)))"')
+         ljv = util.popen_read(Q(cfg.variables["LUA_BINDIR"] .. "/" .. cfg.lua_interpreter) .. ' -e "io.write(tostring(jit and jit.version:gsub([[^%w-JIT ]], [[]])))"')
          if ljv == "nil" then
             ljv = nil
          end


### PR DESCRIPTION
RaptorJIT is a fork of LuaJIT, where jit.version = 'RaptorJIT 1.0.0'

this fix avoids a failure in find_lua_incdir()
    luajitver and prefix .. "/include/luajit-" .. luajitver:match("^(%d+%.%d+)"),
    --> attempt to concatenate a nil value