### PR TITLE
Fix build --no-doc

### DIFF
--- a/src/luarocks/cmd/build.lua
+++ b/src/luarocks/cmd/build.lua
@@ -30,6 +30,7 @@ function cmd_build.add_to_parser(parser)
       :args("?")
 
    cmd:flag("--only-deps", "Installs only the dependencies of the rock.")
+   cmd:flag("--no-doc", "Installs the rock without its documentation.")
    make.cmd_options(cmd)
 end
 


### PR DESCRIPTION
I missed this in #1035.
Note that `build --pack-binary-rock --no-doc` doesn't work (and it never did). I'll submit a fix for that soon.
