### PR TITLE
util: fix cleanup_path order

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -69,6 +69,7 @@ $(builddir)/luarocks: src/bin/luarocks config.unix
 	'package.loaded["luarocks.core.hardcoded"] = { '\
 	"$$([ -n "$(FORCE_CONFIG)" ] && printf 'FORCE_CONFIG = true, ')"\
 	'SYSCONFDIR = [[$(luarocksconfdir)]] }\n'\
+	'package.path=[[$(luadir)/?.lua;]] .. package.path\n'; \
 	'local list = package.searchers or package.loaders; table.insert(list, 1, function(name) if name:match("^luarocks%%.") then return loadfile([[$(luadir)/]] .. name:gsub([[%%.]], [[/]]) .. [[.lua]]) end end)\n'; \
 	tail -n +2 src/bin/luarocks \
 	)> "$@"
@@ -79,6 +80,7 @@ $(builddir)/luarocks-admin: src/bin/luarocks-admin config.unix
 	'package.loaded["luarocks.core.hardcoded"] = { '\
 	"$$([ -n "$(FORCE_CONFIG)" ] && printf 'FORCE_CONFIG = true, ')"\
 	'SYSCONFDIR = [[$(luarocksconfdir)]] }\n'\
+	'package.path=[[$(luadir)/?.lua;]] .. package.path\n'; \
 	'local list = package.searchers or package.loaders; table.insert(list, 1, function(name) if name:match("^luarocks%%.") then return loadfile([[$(luadir)/]] .. name:gsub([[%%.]], [[/]]) .. [[.lua]]) end end)\n'; \
 	tail -n +2 src/bin/luarocks-admin \
 	)> "$@"

--- a/src/luarocks/cmd/path.lua
+++ b/src/luarocks/cmd/path.lua
@@ -35,32 +35,34 @@ function path_cmd.command(args)
    local path_sep = cfg.export_path_separator
 
    if args.lr_path then
-      util.printout(util.cleanup_path(lr_path, ';', cfg.lua_version))
+      util.printout(util.cleanup_path(lr_path, ';', cfg.lua_version, true))
       return true
    elseif args.lr_cpath then
-      util.printout(util.cleanup_path(lr_cpath, ';', cfg.lua_version))
+      util.printout(util.cleanup_path(lr_cpath, ';', cfg.lua_version, true))
       return true
    elseif args.lr_bin then
-      util.printout(util.cleanup_path(lr_bin, path_sep))
+      util.printout(util.cleanup_path(lr_bin, path_sep, nil, true))
       return true
    end
+
+   local clean_path = util.cleanup_path(os.getenv("PATH"), path_sep, nil, true)
    
    if args.append then
       lr_path = package.path .. ";" .. lr_path
       lr_cpath = package.cpath .. ";" .. lr_cpath
-      lr_bin = os.getenv("PATH") .. path_sep .. lr_bin
+      lr_bin = clean_path .. path_sep .. lr_bin
    else
       lr_path =  lr_path.. ";" .. package.path
       lr_cpath = lr_cpath .. ";" .. package.cpath
-      lr_bin = lr_bin .. path_sep .. os.getenv("PATH")
+      lr_bin = lr_bin .. path_sep .. clean_path
    end
    
    local lpath_var, lcpath_var = util.lua_path_variables()
 
-   util.printout(fs.export_cmd(lpath_var, util.cleanup_path(lr_path, ';', cfg.lua_version)))
-   util.printout(fs.export_cmd(lcpath_var, util.cleanup_path(lr_cpath, ';', cfg.lua_version)))
+   util.printout(fs.export_cmd(lpath_var, util.cleanup_path(lr_path, ';', cfg.lua_version, args.append)))
+   util.printout(fs.export_cmd(lcpath_var, util.cleanup_path(lr_cpath, ';', cfg.lua_version, args.append)))
    if not args.no_bin then
-      util.printout(fs.export_cmd("PATH", util.cleanup_path(lr_bin, path_sep)))
+      util.printout(fs.export_cmd("PATH", util.cleanup_path(lr_bin, path_sep, nil, args.append)))
    end
    return true
 end

--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -763,8 +763,8 @@ function cfg.init(detected, warning)
 
    function cfg.init_package_paths()
       local lr_path, lr_cpath, lr_bin = cfg.package_paths()
-      package.path = util.cleanup_path(package.path .. ";" .. lr_path, ";", lua_version)
-      package.cpath = util.cleanup_path(package.cpath .. ";" .. lr_cpath, ";", lua_version)
+      package.path = util.cleanup_path(package.path .. ";" .. lr_path, ";", lua_version, true)
+      package.cpath = util.cleanup_path(package.cpath .. ";" .. lr_cpath, ";", lua_version, true)
    end
 
    --- Check if platform was detected

--- a/src/luarocks/core/util.lua
+++ b/src/luarocks/core/util.lua
@@ -167,16 +167,16 @@ end
 -- @param list string: A path string (from $PATH or package.path)
 -- @param sep string: The separator
 -- @param lua_version (optional) string: The Lua version to use.
--- @param keep_last (optional) if true, keep last occurrence in case
--- of duplicates; otherwise keep first occurrence. The default is false.
-function util.cleanup_path(list, sep, lua_version, keep_last)
+-- @param keep_first (optional) if true, keep first occurrence in case
+-- of duplicates; otherwise keep last occurrence. The default is false.
+function util.cleanup_path(list, sep, lua_version, keep_first)
    assert(type(list) == "string")
    assert(type(sep) == "string")
    local parts = util.split_string(list, sep)
    local final, entries = {}, {}
    local start, stop, step
 
-   if keep_last then
+   if keep_first then
       start, stop, step = 1, #parts, 1
    else
       start, stop, step = #parts, 1, -1
@@ -192,11 +192,12 @@ function util.cleanup_path(list, sep, lua_version, keep_last)
          end)
       end
       if not entries[part] then
-         local at = keep_last and #final+1 or 1
+         local at = keep_first and #final+1 or 1
          table.insert(final, at, part)
          entries[part] = true
       end
    end
+
    return table.concat(final, sep)
 end
 


### PR DESCRIPTION
I believe the `command unknown` errors experienced in #1070 are related to this, as I saw similar behavior when attempting to do a local bootstrap install in `$HOME/.luarocks` running 3.2.0 (plus recent fixes).

This change ensures that the package path fixups done by the bin wrapper take effect.

Commit 72d80a35 had the default behavior inverted, and affected its use in `luarocks.core.cfg`.

Commit 0823c4dd62e accidentally removed the use of `flags["append"]` in `luarocks.cmd.path` and this slipped code review. This restores it.