### PR TITLE
build: fix --branch flag

### DIFF
--- a/spec/install_spec.lua
+++ b/spec/install_spec.lua
@@ -3,8 +3,8 @@ local lfs = require("lfs")
 local run = test_env.run
 local testing_paths = test_env.testing_paths
 local env_variables = test_env.env_variables
-local get_tmp_path = test_env.get_tmp_path
 local write_file = test_env.write_file
+local git_repo = require("spec.util.git_repo")
 
 test_env.unload_luarocks()
 
@@ -231,6 +231,33 @@ describe("luarocks install #integration", function()
          assert(run.luarocks_bool("install has_build_dep --server=" .. testing_paths.fixtures_dir .. "/a_repo" ))
          assert(run.luarocks_bool("show has_build_dep 1.0"))
          assert.falsy(run.luarocks_bool("show a_build_dep 1.0"))
+      end)
+   end)
+
+   describe("#unix install runs build from #git", function()
+      local git
+
+      setup(function()
+         git = git_repo.start()
+      end)
+      
+      teardown(function()
+         if git then
+            git:stop()
+         end
+      end)
+
+      it("using --branch", function()
+         write_file("my_branch-1.0-1.rockspec", [[
+            rockspec_format = "3.0"
+            package = "my_branch"
+            version = "1.0-1"
+            source = {
+               url = "git://localhost/testrock"
+            }
+         ]], finally)
+         assert.is_false(run.luarocks_bool("install --branch unknown-branch ./my_branch-1.0-1.rockspec"))
+         assert.is_true(run.luarocks_bool("install --branch test-branch ./my_branch-1.0-1.rockspec"))
       end)
    end)
 

--- a/spec/util/git_repo.lua
+++ b/spec/util/git_repo.lua
@@ -82,6 +82,7 @@ function git_repo.start()
             test_env.execute("git add " .. name)
          end
          assert(test_env.execute("git commit -a -m 'initial commit'"))
+         assert(test_env.execute("git branch test-branch"))
          print("git daemon --reuseaddr --pid-file="..pidfile.." --base-path="..basedir.." --export-all "..repodir.." &")
          assert(test_env.execute("git daemon --reuseaddr --pid-file="..pidfile.." --base-path="..basedir.." --export-all "..repodir.." &"))
          assert(test_env.execute("sleep 0.1; netstat -ln | grep '0.0.0.0:9418 .* LISTEN'"))

--- a/src/luarocks/build.lua
+++ b/src/luarocks/build.lua
@@ -18,7 +18,7 @@ build.opts = util.opts_table("build.opts", {
    deps_mode = "string",
    build_only_deps = "boolean",
    namespace = "string?",
-   branch = "boolean",
+   branch = "string?",
    verify = "boolean",
 })
 
@@ -337,18 +337,7 @@ local function write_rock_dir_files(rockspec, opts)
 end
 
 --- Build and install a rock given a rockspec.
--- @param rockspec_file string: local or remote filename of a rockspec.
--- @param need_to_fetch boolean: true if sources need to be fetched,
--- false if the rockspec was obtained from inside a source rock.
--- @param minimal_mode boolean: true if there's no need to fetch,
--- unpack or change dir (this is used by "luarocks make"). Implies
--- need_to_fetch = false.
--- @param deps_mode string: Dependency mode: "one" for the current default tree,
--- "all" for all trees, "order" for all trees with priority >= the current default,
--- "none" for no trees.
--- @param build_only_deps boolean: true to build the listed dependencies only.
--- @param namespace string?: a namespace for the rockspec
--- @param branch string?: a forced branch to use
+-- @param opts table: build options table
 -- @return (string, string) or (nil, string, [string]): Name and version of
 -- installed rock if succeeded or nil and an error message followed by an error code.
 function build.build_rockspec(rockspec, opts)

--- a/src/luarocks/cmd/build.lua
+++ b/src/luarocks/cmd/build.lua
@@ -31,6 +31,10 @@ function cmd_build.add_to_parser(parser)
 
    cmd:flag("--only-deps", "Installs only the dependencies of the rock.")
    cmd:flag("--no-doc", "Installs the rock without its documentation.")
+   cmd:option("--branch", "Override the `source.branch` field in the loaded "..
+      "rockspec. Allows to specify a different branch to fetch. Particularly "..
+      'for "dev" rocks.')
+      :argname("<name>")
    make.cmd_options(cmd)
 end
 
@@ -131,7 +135,7 @@ function cmd_build.command(args)
       deps_mode = deps.get_deps_mode(args),
       build_only_deps = not not args.only_deps,
       namespace = args.namespace,
-      branch = not not args.branch,
+      branch = args.branch,
       verify = not not args.verify,
    })
 

--- a/src/luarocks/cmd/install.lua
+++ b/src/luarocks/cmd/install.lua
@@ -42,7 +42,7 @@ function install.add_to_parser(parser)
    util.deps_mode_option(cmd)
    -- luarocks build options
    parser:flag("--pack-binary-rock"):hidden(true)
-   parser:flag("--branch"):hidden(true)
+   parser:option("--branch"):hidden(true)
    parser:flag("--sign"):hidden(true)
 end
 

--- a/src/luarocks/cmd/make.lua
+++ b/src/luarocks/cmd/make.lua
@@ -26,10 +26,6 @@ function make.cmd_options(parser)
       "previously installed versions if it would break dependencies.")
    parser:flag("--force-fast", "Like --force, but performs a forced removal "..
       "without reporting dependency issues.")
-   parser:option("--branch", "Override the `source.branch` field in the loaded "..
-      "rockspec. Allows to specify a different branch to fetch. Particularly "..
-      'for "dev" rocks.')
-      :argname("<name>")
    parser:flag("--verify", "Verify signature of the rockspec or src.rock being "..
       "built. If the rockspec or src.rock is being downloaded, LuaRocks will "..
       "attempt to download the signature as well. Otherwise, the signature "..
@@ -95,7 +91,7 @@ function make.command(args)
       deps_mode = deps.get_deps_mode(args),
       build_only_deps = false,
       namespace = args.namespace,
-      branch = not not args.branch,
+      branch = args.branch,
       verify = not not args.verify,
    })
 


### PR DESCRIPTION
The `--branch` flag is optional and takes a string argument. This fixes the propagation of the string value.

The `--branch` flag does not make sense for `luarocks make` because it does not fetch sources, it builds/installs based on whatever is in the current directory.

This also adds tests that verify the behavior, but these don't run in Travis CI because of issues running a Git daemon there. They were verified locally.

Fixes #1077.