### PR TITLE
Fix manif.load_manifest changing current directory

### DIFF
--- a/src/luarocks/manif.lua
+++ b/src/luarocks/manif.lua
@@ -135,10 +135,10 @@ function manif.load_manifest(repo_url, lua_version, versioned_only)
    end
    if pathname:match(".*%.zip$") then
       pathname = fs.absolute_name(pathname)
-      local dirname = dir.dir_name(pathname)
-      fs.change_dir(dirname)
       local nozip = pathname:match("(.*)%.zip$")
       if not from_cache then
+         local dirname = dir.dir_name(pathname)
+         fs.change_dir(dirname)
          fs.delete(nozip)
          local ok, err = fs.unzip(pathname)
          fs.pop_dir()


### PR DESCRIPTION
Since https://github.com/luarocks/luarocks/commit/b3d36513baa15b5c7b4c1ad24f655e3469b83dc5 `fs.pop_dir` wasn't being called after `fs.change_dir` in some cases.

I noticed this because `luarocks build --pack-binary-rock <name>` was putting the rock file in `~/.cache/luarocks` instead of the current directory.