### PR TITLE
Fix version detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ integration_script: &integration_script
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then shellcheck ./configure; fi
   - ./configure --with-lua=lua_install
   - ./makedist dev
+  - ./smoke_test.sh luarocks-dev.tar.gz
   - busted -o gtest --exclude-tags=gpg,git,unit --verbose -Xhelper "lua_dir=$PWD/lua_install,travis"
   - busted -o gtest --exclude-tags=gpg,git,unit --verbose -Xhelper "lua_dir=$PWD/lua_install,travis,env=full"
           

--- a/src/luarocks/util.lua
+++ b/src/luarocks/util.lua
@@ -436,6 +436,9 @@ do
          return nil
       end
       local lv, err = util.popen_read(Q(lua_exe) .. ' -e "io.write(_VERSION:sub(5))"')
+      if lv == "" then
+         return nil
+      end
       if luaver and luaver ~= lv then
          return nil
       end


### PR DESCRIPTION
This might be the source of troubles with users seeing `lua5.1` being incorrectly detected as the interpreter name.