### PR TITLE
fix local search of manifests

### DIFF
--- a/src/luarocks/search.lua
+++ b/src/luarocks/search.lua
@@ -108,7 +108,7 @@ local function manifest_search(result_tree, repo, query, lua_version, is_local)
       repo = repo .. "/manifests/" .. query.namespace
    end
 
-   local manifest, err, errcode = manif.load_manifest(repo, lua_version, true)
+   local manifest, err, errcode = manif.load_manifest(repo, lua_version, not is_local)
    if not manifest then
       return nil, err, errcode
    end


### PR DESCRIPTION
Since #1065 it was failing to find the unversioned `manifest` files inside `<rocks_tree>/lib/luarocks/rocks-5.x/`. The result was that `luarocks install foo` worked but then `luarocks show foo` didn't. `search.local_manifest_search` (which is used by `search.pick_installed_rock`) should include unversioned manifest files.

What's odd is how the test files for `luarocks show` didn't catch this.