### PR TITLE
Refactor command line handling of namespaces

### DIFF
--- a/src/luarocks/cmd.lua
+++ b/src/luarocks/cmd.lua
@@ -393,6 +393,7 @@ Enabling completion for Fish:
    parser:option("--only-sources", "Restrict downloads to paths matching the given URL.")
       :argname("<url>")
    parser:option("--namespace", "Specify the rocks server namespace to use.")
+      :convert(string.lower)
    parser:option("--lua-dir", "Which Lua installation to use.")
       :argname("<prefix>")
    parser:option("--lua-version", "Which Lua version to use.")

--- a/src/luarocks/cmd/download.lua
+++ b/src/luarocks/cmd/download.lua
@@ -11,6 +11,7 @@ function cmd_download.add_to_parser(parser)
 
    cmd:argument("name", "Name of the rock.")
       :args("?")
+      :action(util.namespaced_name_action)
    cmd:argument("version", "Version of the rock.")
       :args("?")
 
@@ -29,9 +30,7 @@ function cmd_download.command(args)
       return nil, "Argument missing. "..util.see_help("download")
    end
 
-   local name = util.adjust_name_and_namespace(args.name, args)
-
-   if not name then name, args.version = "", "" end
+   args.name = args.name or ""
 
    local arch
 
@@ -43,7 +42,7 @@ function cmd_download.command(args)
       arch = args.arch
    end
    
-   local dl, err = download.download(arch, name:lower(), args.version, args.all)
+   local dl, err = download.download(arch, args.name, args.namespace, args.version, args.all)
    return dl and true, err
 end
 

--- a/src/luarocks/cmd/install.lua
+++ b/src/luarocks/cmd/install.lua
@@ -21,6 +21,7 @@ function install.add_to_parser(parser)
 
    cmd:argument("rock", "The name of a rock to be fetched from a repository "..
       "or a filename of a locally available rock.")
+      :action(util.namespaced_name_action)
    cmd:argument("version", "Version of the rock.")
       :args("?")
 
@@ -219,8 +220,6 @@ end
 -- @return boolean or (nil, string, exitcode): True if installation was
 -- successful, nil and an error message otherwise. exitcode is optionally returned.
 function install.command(args)
-   args.rock = util.adjust_name_and_namespace(args.rock, args)
-
    local ok, err = fs.check_command_permissions(args)
    if not ok then return nil, err, cmd.errorcodes.PERMISSIONDENIED end
 
@@ -244,7 +243,7 @@ function install.command(args)
          return install_rock_file(args.rock, opts)
       end
    else
-      local url, err = search.find_suitable_rock(queries.new(args.rock:lower(), args.version), true)
+      local url, err = search.find_suitable_rock(queries.new(args.rock, args.namespace, args.version), true)
       if not url then
          return nil, err
       end

--- a/src/luarocks/cmd/list.lua
+++ b/src/luarocks/cmd/list.lua
@@ -69,7 +69,7 @@ end
 --- Driver function for "list" command.
 -- @return boolean: True if succeeded, nil on errors.
 function list.command(args)
-   local query = queries.new(args.filter and args.filter:lower() or "", args.version, true)
+   local query = queries.new(args.filter and args.filter:lower() or "", args.namespace, args.version, true)
    local trees = cfg.rocks_trees
    local title = "Rocks installed for Lua "..cfg.lua_version
    if args.tree then

--- a/src/luarocks/cmd/make.lua
+++ b/src/luarocks/cmd/make.lua
@@ -83,14 +83,15 @@ function make.command(args)
       return nil, err
    end
 
-   local name = util.adjust_name_and_namespace(rockspec.name, args)
+   local name, namespace = util.split_namespace(rockspec.name)
+   namespace = namespace or args.namespace
 
    local opts = build.opts({
       need_to_fetch = false,
       minimal_mode = true,
       deps_mode = deps.get_deps_mode(args),
       build_only_deps = false,
-      namespace = args.namespace,
+      namespace = namespace,
       branch = args.branch,
       verify = not not args.verify,
    })
@@ -100,7 +101,7 @@ function make.command(args)
    end
 
    if args.pack_binary_rock then
-      return pack.pack_binary_rock(name, rockspec.version, args.sign, function()
+      return pack.pack_binary_rock(name, namespace, rockspec.version, args.sign, function()
          return build.build_rockspec(rockspec, opts)
       end)
    else

--- a/src/luarocks/cmd/pack.lua
+++ b/src/luarocks/cmd/pack.lua
@@ -13,6 +13,7 @@ function cmd_pack.add_to_parser(parser)
 
    cmd:argument("rock", "A rockspec file, for creating a source rock, or the "..
       "name of an installed package, for creating a binary rock.")
+      :action(util.namespaced_name_action)
    cmd:argument("version", "A version may be given if the first argument is a rock name.")
       :args("?")
 
@@ -27,8 +28,7 @@ function cmd_pack.command(args)
    if args.rock:match(".*%.rockspec") then
       file, err = pack.pack_source_rock(args.rock)
    else
-      local name = util.adjust_name_and_namespace(args.rock, args)
-      local query = queries.new(name, args.version)
+      local query = queries.new(args.rock, args.namespace, args.version)
       file, err = pack.pack_installed_rock(query, args.tree)
    end
    return pack.report_and_sign_local_file(file, err, args.sign)

--- a/src/luarocks/cmd/search.lua
+++ b/src/luarocks/cmd/search.lua
@@ -14,6 +14,7 @@ function cmd_search.add_to_parser(parser)
 
    cmd:argument("name", "Name of the rock to search for.")
       :args("?")
+      :action(util.namespaced_name_action)
    cmd:argument("version", "Rock version to search for.")
       :args("?")
 
@@ -53,8 +54,7 @@ end
 -- @return boolean or (nil, string): True if build was successful; nil and an
 -- error message otherwise.
 function cmd_search.command(args)
-
-   local name = util.adjust_name_and_namespace(args.name, args)
+   local name = args.name
 
    if args.all then
       name, args.version = "", nil
@@ -64,10 +64,10 @@ function cmd_search.command(args)
       return nil, "Enter name and version or use --all. "..util.see_help("search")
    end
    
-   local query = queries.new(name:lower(), args.version, true)
+   local query = queries.new(name, args.namespace, args.version, true)
    local result_tree, err = search.search_repos(query)
    local porcelain = args.porcelain
-   local full_name = name .. (args.version and " " .. args.version or "")
+   local full_name = util.format_rock_name(name, args.namespace, args.version)
    util.title(full_name .. " - Search results for Lua "..cfg.lua_version..":", porcelain, "=")
    local sources, binaries = split_source_and_binary_results(result_tree)
    if next(sources) and not args.binary then

--- a/src/luarocks/cmd/show.lua
+++ b/src/luarocks/cmd/show.lua
@@ -22,6 +22,7 @@ With flags, return only the desired information.]], util.see_also())
       :summary("Show information about an installed rock.")
 
    cmd:argument("rock", "Name of an installed rock.")
+      :action(util.namespaced_name_action)
    cmd:argument("version", "Rock version.")
       :args("?")
 
@@ -260,12 +261,9 @@ end
 --- Driver function for "show" command.
 -- @return boolean: True if succeeded, nil on errors.
 function show.command(args)
-   local name = util.adjust_name_and_namespace(args.rock, args)
-   local version = args.version
-   local query = queries.new(name, version)
+   local query = queries.new(args.rock, args.namespace, args.version)
    
-   local repo, repo_url
-   name, version, repo, repo_url = search.pick_installed_rock(query, args.tree)
+   local name, version, repo, repo_url = search.pick_installed_rock(query, args.tree)
    if not name then
       return nil, version
    end

--- a/src/luarocks/cmd/unpack.lua
+++ b/src/luarocks/cmd/unpack.lua
@@ -19,6 +19,7 @@ In the latter case, the rock version may be given as a second argument.]],
       :summary("Unpack the contents of a rock.")
 
    cmd:argument("rock", "A rock file or the name of a rock.")
+      :action(util.namespaced_name_action)
    cmd:argument("version", "Rock version.")
       :args("?")
 
@@ -149,13 +150,11 @@ end
 -- @return boolean or (nil, string): true if successful or nil followed
 -- by an error message.
 function unpack.command(args)
-   local ns_name = util.adjust_name_and_namespace(args.rock, args)
-
    local url, err
-   if ns_name:match(".*%.rock") or ns_name:match(".*%.rockspec") then
-      url = ns_name
+   if args.rock:match(".*%.rock") or args.rock:match(".*%.rockspec") then
+      url = args.rock
    else
-      url, err = search.find_src_or_rockspec(ns_name, args.version, true)
+      url, err = search.find_src_or_rockspec(args.rock, args.namespace, args.version, true)
       if not url then
          return nil, err
       end

--- a/src/luarocks/cmd/write_rockspec.lua
+++ b/src/luarocks/cmd/write_rockspec.lua
@@ -263,9 +263,7 @@ local function rockspec_cleanup(rockspec)
 end
 
 function write_rockspec.command(args)
-
-   local name = util.adjust_name_and_namespace(args.name, args)
-   local version = args.version
+   local name, version = args.name, args.version
    local location = args.location
 
    if not name then

--- a/src/luarocks/download.lua
+++ b/src/luarocks/download.lua
@@ -6,6 +6,7 @@ local search = require("luarocks.search")
 local queries = require("luarocks.queries")
 local fs = require("luarocks.fs")
 local dir = require("luarocks.dir")
+local util = require("luarocks.util")
 
 local function get_file(filename)
    local protocol, pathname = dir.split_url(filename)
@@ -21,9 +22,9 @@ local function get_file(filename)
    end
 end
 
-function download.download(arch, name, version, all)
+function download.download(arch, name, namespace, version, all)
    local substring = (all and name == "")
-   local query = queries.new(name, version, substring, arch)
+   local query = queries.new(name, namespace, version, substring, arch)
    local search_err
 
    if all then
@@ -58,8 +59,8 @@ function download.download(arch, name, version, all)
          return get_file(url)
       end
    end
-   return nil, "Could not find a result named "..name..(version and " "..version or "")..
-      (search_err and ": "..search_err or ".")
+   local rock = util.format_rock_name(name, namespace, version)
+   return nil, "Could not find a result named "..rock..(search_err and ": "..search_err or ".")
 end
 
 return download

--- a/src/luarocks/pack.lua
+++ b/src/luarocks/pack.lua
@@ -137,7 +137,7 @@ function pack.report_and_sign_local_file(file, err, sign)
    end
    util.printout("Packed: "..file)
    if sigfile then
-      util.printout("Sigature stored in: "..sigfile)
+      util.printout("Signature stored in: "..sigfile)
    end
    if err then
       return nil, err
@@ -145,7 +145,7 @@ function pack.report_and_sign_local_file(file, err, sign)
    return true
 end
 
-function pack.pack_binary_rock(name, version, sign, cmd)
+function pack.pack_binary_rock(name, namespace, version, sign, cmd)
 
    -- The --pack-binary-rock option for "luarocks build" basically performs
    -- "luarocks build" on a temporary tree and then "luarocks pack". The
@@ -169,7 +169,7 @@ function pack.pack_binary_rock(name, version, sign, cmd)
    if not rname then
       rname, rversion = name, version
    end
-   local query = queries.new(rname, rversion)
+   local query = queries.new(rname, namespace, rversion)
    local file, err = pack.pack_installed_rock(query, temp_dir)
    return pack.report_and_sign_local_file(file, err, sign)
 end

--- a/src/luarocks/queries.lua
+++ b/src/luarocks/queries.lua
@@ -40,15 +40,17 @@ local function arch_to_table(input)
 end
 
 --- Prepare a query in dependency table format.
--- @param ns_name string: the package name, may contain a namespace.
+-- @param name string: the package name.
+-- @param namespace string?: the package namespace.
 -- @param version string?: the package version.
 -- @param substring boolean?: match substrings of the name
 -- (default is false, match full name)
 -- @param arch string?: a string with pipe-separated accepted arch values
 -- @param operator string?: operator for version matching (default is "==")
 -- @return table: A query in table format
-function queries.new(ns_name, version, substring, arch, operator)
-   assert(type(ns_name) == "string")
+function queries.new(name, namespace, version, substring, arch, operator)
+   assert(type(name) == "string")
+   assert(type(namespace) == "string" or not namespace)
    assert(type(version) == "string" or not version)
    assert(type(substring) == "boolean" or not substring)
    assert(type(arch) == "string" or not arch)
@@ -56,8 +58,6 @@ function queries.new(ns_name, version, substring, arch, operator)
    
    operator = operator or "=="
 
-   local name, namespace = util.split_namespace(ns_name)
-   
    local self = {
       name = name,
       namespace = namespace,
@@ -78,7 +78,7 @@ end
 function queries.all(arch)
    assert(type(arch) == "string" or not arch)
 
-   return queries.new("", nil, true, arch)
+   return queries.new("", nil, nil, true, arch)
 end
 
 do

--- a/src/luarocks/remove.lua
+++ b/src/luarocks/remove.lua
@@ -105,7 +105,7 @@ end
 
 function remove.remove_other_versions(name, version, force, fast)
    local results = {}
-   local query = queries.new(name, version, false, nil, "~=")
+   local query = queries.new(name, nil, version, false, nil, "~=")
    search.local_manifest_search(results, cfg.rocks_dir, query)
    if results[name] then
       return remove.remove_search_results(results, name, cfg.deps_mode, force, fast)

--- a/src/luarocks/search.lua
+++ b/src/luarocks/search.lua
@@ -225,8 +225,8 @@ local function supported_lua_versions(query, cli)
    return result_tree
 end
 
-function search.find_src_or_rockspec(ns_name, version, cli)
-   local query = queries.new(ns_name, version, false, "src|rockspec")
+function search.find_src_or_rockspec(name, namespace, version, cli)
+   local query = queries.new(name, namespace, version, false, "src|rockspec")
    local url, err = search.find_suitable_rock(query, cli)
    if not url then
       return nil, "Could not find a result named "..tostring(query)..": "..err


### PR DESCRIPTION
https://github.com/luarocks/luarocks/issues/1067

Rock name and namespace are always passed around separately to avoid splitting them multiple times.