### PR TITLE
win32: fix split root for quoted absolute path handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,13 +35,13 @@ jobs:
   include:
     # Smoke tests for release branches
     - stage: smoke
-      if: branch =~ [0-9].*
+      if: branch =~ ^[0-9].*
       script: *smoke_script
       os: linux
       env:
         - LUA="lua=5.3"
     - stage: smoke
-      if: branch =~ [0-9].*
+      if: branch =~ ^[0-9].*
       script: *smoke_script
       os: osx
       language: generic

--- a/spec/fs_spec.lua
+++ b/spec/fs_spec.lua
@@ -88,6 +88,40 @@ describe("Luarocks fs test #unit", function()
          assert.are.same(is_win and [["\\"%" \\\\" \\\\\\"]] or [['\% \\" \\\']], fs.Q([[\% \\" \\\]]))
       end)
    end)
+
+   describe("fs.absolute_name", function()
+      it("unchanged if already absolute", function()
+         if is_win then
+            assert.are.same("c:\\foo\\bar", fs.absolute_name("\"c:\\foo\\bar\""))
+            assert.are.same("c:\\foo\\bar", fs.absolute_name("c:\\foo\\bar"))
+            assert.are.same("d:\\foo\\bar", fs.absolute_name("d:\\foo\\bar"))
+            assert.are.same("\\foo\\bar", fs.absolute_name("\\foo\\bar"))
+         else
+            assert.are.same("/foo/bar", fs.absolute_name("/foo/bar"))
+         end
+      end)
+
+      it("converts to absolute if relative", function()
+         local cur = fs.current_dir()
+         if is_win then
+            assert.are.same(cur .. "/foo\\bar", fs.absolute_name("\"foo\\bar\""))
+            assert.are.same(cur .. "/foo\\bar", fs.absolute_name("foo\\bar"))
+         else
+            assert.are.same(cur .. "/foo/bar", fs.absolute_name("foo/bar"))
+         end
+      end)
+
+      it("converts a relative to specified base if given", function()
+         if is_win then
+            assert.are.same("c:\\bla/foo\\bar", fs.absolute_name("\"foo\\bar\"", "c:\\bla"))
+            assert.are.same("c:\\bla/foo\\bar", fs.absolute_name("foo\\bar", "c:\\bla"))
+            assert.are.same("c:\\bla/foo\\bar", fs.absolute_name("foo\\bar", "c:\\bla\\"))
+         else
+            assert.are.same("/bla/foo/bar", fs.absolute_name("foo/bar", "/bla"))
+            assert.are.same("/bla/foo/bar", fs.absolute_name("foo/bar", "/bla/"))
+         end
+      end)
+   end)
    
    describe("fs.execute_string", function()
       local tmpdir

--- a/src/luarocks/fs/unix.lua
+++ b/src/luarocks/fs/unix.lua
@@ -42,7 +42,12 @@ function unix.absolute_name(pathname, relative_to)
    assert(type(pathname) == "string")
    assert(type(relative_to) == "string" or not relative_to)
 
-   relative_to = relative_to or fs.current_dir()
+   local unquoted = pathname:match("^['\"](.*)['\"]$")
+   if unquoted then
+      pathname = unquoted
+   end
+
+   relative_to = (relative_to or fs.current_dir()):gsub("/*$", "")
    if pathname:sub(1,1) == "/" then
       return pathname
    else


### PR DESCRIPTION
This should fix issue #1107 where a quoted path was incorrectly
detected as a relative one.

Fix #1107