### PR TITLE
Windows on ARM support

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -399,6 +399,8 @@ end
 local function get_runtime()
 	local f
 	vars.LUA_RUNTIME, f = pe.msvcrt(vars.LUA_BINDIR.."\\"..vars.LUA_INTERPRETER)
+	print("msvcrt: " .. f)
+	print("vars.LUA_RUNTIME" .. vars.LUA_RUNTIME)
 	if type(vars.LUA_RUNTIME) ~= "string" then
 		-- analysis failed, issue a warning
 		vars.LUA_RUNTIME = "MSVCR80"
@@ -415,9 +417,12 @@ local function get_architecture()
 	if not proc then
 		die("Could not detect processor architecture used in "..vars.LUA_INTERPRETER)
 	end
+	print("arch: " .. proc .. " -> " .. pe.const.Machine[proc] )
 	proc = pe.const.Machine[proc]  -- collect name from constant value
 	if proc == "IMAGE_FILE_MACHINE_I386" then
 		proc = "x86"
+	elseif proc == "IMAGE_FILE_MACHINE_ARM64" then
+		proc = "arm64"
 	else
 		proc = "x86_64"
 	end
@@ -554,8 +559,8 @@ local function get_msvc_env_setup_cmd()
 	if vsdir then
 		local vcvarsall = vsdir .. '\\VC\\Auxiliary\\Build\\vcvarsall.bat'
 		if exists(vcvarsall) then
-			local vcvarsall_args = { x86 = "", x86_64 = " x64" }
-			assert(vcvarsall_args[vars.UNAME_M], "vars.UNAME_M: only x86 and x86_64 are supported")
+			local vcvarsall_args = { x86 = "", x86_64 = " x64", arm64 = " x86_arm64" }
+			assert(vcvarsall_args[vars.UNAME_M], "vars.UNAME_M: only x86, x86_64 and arm64 are supported")
 			return ('call "%s"%s'):format(vcvarsall, vcvarsall_args[vars.UNAME_M])
 		end
 	end
@@ -571,9 +576,12 @@ local function get_msvc_env_setup_cmd()
 			x86_64 = {
 				"bin\\amd64\\vcvars64.bat", -- prefers native compiler
 				"bin\\x86_amd64\\vcvarsx86_amd64.bat" -- then cross compiler
+			},
+			arm64 = {
+				"bin\\x86_arm64\\vcvarsx86_arm64.bat" -- need to use cross compiler"
 			}
 		}
-		assert(vcvars_bats[vars.UNAME_M], "vars.UNAME_M: only x86 and x86_64 are supported")
+		assert(vcvars_bats[vars.UNAME_M], "vars.UNAME_M: only x86, arm64 and x86_64 are supported")
 		for _, bat in ipairs(vcvars_bats[vars.UNAME_M]) do
 			local full_path = vcdir .. bat
 			if exists(full_path) then
@@ -585,7 +593,7 @@ local function get_msvc_env_setup_cmd()
 		-- but this way we don't know if specified compiler is installed...
 		local vcvarsall = vcdir .. 'vcvarsall.bat'
 		if exists(vcvarsall) then
-			local vcvarsall_args = { x86 = "", x86_64 = " amd64" }
+			local vcvarsall_args = { x86 = "", x86_64 = " amd64", arm64 = " x86_arm64" }
 			return ('call "%s"%s'):format(vcvarsall, vcvarsall_args[vars.UNAME_M])
 		end
 	end

--- a/install.bat
+++ b/install.bat
@@ -399,8 +399,6 @@ end
 local function get_runtime()
 	local f
 	vars.LUA_RUNTIME, f = pe.msvcrt(vars.LUA_BINDIR.."\\"..vars.LUA_INTERPRETER)
-	print("msvcrt: " .. f)
-	print("vars.LUA_RUNTIME" .. vars.LUA_RUNTIME)
 	if type(vars.LUA_RUNTIME) ~= "string" then
 		-- analysis failed, issue a warning
 		vars.LUA_RUNTIME = "MSVCR80"

--- a/install.bat
+++ b/install.bat
@@ -415,7 +415,7 @@ local function get_architecture()
 	if not proc then
 		die("Could not detect processor architecture used in "..vars.LUA_INTERPRETER)
 	end
-	print("arch: " .. proc .. " -> " .. pe.const.Machine[proc] )
+	print("arch: " .. proc .. " -> " .. pe.const.Machine[proc])
 	proc = pe.const.Machine[proc]  -- collect name from constant value
 	if proc == "IMAGE_FILE_MACHINE_I386" then
 		proc = "x86"


### PR DESCRIPTION
This PR adds support for using Luarocks from a Windows on ARM machine. These machines use Visual Studio running under their built-in x86-32 emulation to cross-compile into ARM64 native binaries.

I've patched `install.bat` to detect when it is running under ARM64 and select the appropriate cross-compiler.

I've successfully used it to install some rocks such as LuaFileSystem, busted, lpeg, so I think it is working. There were some failures but mostly due to C code that assumes UNIX and tries to include header files which are not present on standard Visual Studio installs. 