### PR TITLE
Add OpenBSD specific dependency paths.

### DIFF
--- a/configure
+++ b/configure
@@ -435,6 +435,7 @@ check_incdir() {
       "$incdir/lua$LUA_VERSION/lua.h" \
       "$incdir/lua$(echo "$LUA_VERSION" | tr -d .)/lua.h" \
       "$incdir/lua.h" \
+      "$incdir/lua-$LUA_VERSION/lua.h" \
       $("$LUA_BINDIR/$LUA_INTERPRETER" -e 'print(jit and [['"$incdir"'/luajit-]]..jit.version:match("(%d+%.%d+)")..[[/lua.h]] or "")')
    do
       [ -f "$lua_h" ] && return

--- a/configure
+++ b/configure
@@ -433,9 +433,9 @@ check_incdir() {
    for lua_h in \
       "$incdir/lua/$LUA_VERSION/lua.h" \
       "$incdir/lua$LUA_VERSION/lua.h" \
+      "$incdir/lua-$LUA_VERSION/lua.h" \
       "$incdir/lua$(echo "$LUA_VERSION" | tr -d .)/lua.h" \
       "$incdir/lua.h" \
-      "$incdir/lua-$LUA_VERSION/lua.h" \
       $("$LUA_BINDIR/$LUA_INTERPRETER" -e 'print(jit and [['"$incdir"'/luajit-]]..jit.version:match("(%d+%.%d+)")..[[/lua.h]] or "")')
    do
       [ -f "$lua_h" ] && return

--- a/src/luarocks/deps.lua
+++ b/src/luarocks/deps.lua
@@ -656,6 +656,7 @@ local function find_lua_incdir(prefix, luaver, luajitver)
       prefix .. "/include/lua/" .. luaver,
       prefix .. "/include/lua" .. luaver,
       prefix .. "/include/lua" .. shortv,
+      prefix .. "/include/lua-" .. luaver,
       prefix .. "/include",
       prefix,
       luajitver and prefix .. "/include/luajit-" .. luajitver:match("^(%d+%.%d+)"),


### PR DESCRIPTION
This commit enables luarocks to be configured and build on OpenBSD.
The lua header files reside in /usr/local/include/lua-5.3/ and this changes tell the configure script and deps.lua about it.