### PR TITLE
Add snapcraft configuration for building snap packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 /luarocks
 /luarocks-admin
 /.luarocks
+/*.snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,33 @@
+name: luarocks
+base: core18
+version: git
+summary: LuaRocks is the package manager for the Lua programming language. # 79 char long summary
+description: |
+  It allows you to install Lua modules as self-contained packages called rocks, which also contain version dependency information.
+  This information can be used both during installation, so that when one rock is requested all rocks it depends on are installed as well, and also optionally at run time, so that when a module is required, the correct version is loaded.
+  LuaRocks supports both local and remote repositories, and multiple local rocks trees.
+
+grade: stable # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
+
+parts: # I am not sure how to do this part really, I guess the make plugin is the most appropriate to use for luarocks?
+  luarocks:
+    plugin: make
+    source: .
+    build-packages:  
+      - build-essential
+      - libreadline-dev
+    stage-packages:
+      - lua5.3
+      - liblua5.3-dev
+      - unzip
+    override-build: |
+      ./configure --prefix=/root/parts/luarocks/install/usr/local
+      make build
+      make install
+    prime:
+      - usr/local/bin
+
+apps:
+  luarocks:
+    command: usr/local/bin/luarocks

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,9 +8,9 @@ description: |
   LuaRocks supports both local and remote repositories, and multiple local rocks trees.
 
 grade: stable # must be 'stable' to release into candidate/stable channels
-confinement: devmode # use 'strict' once you have the right plugs and slots
+confinement: strict # should be replaced with 'strict'
 
-parts: # I am not sure how to do this part really, I guess the make plugin is the most appropriate to use for luarocks?
+parts:
   luarocks:
     plugin: make
     source: .
@@ -22,12 +22,12 @@ parts: # I am not sure how to do this part really, I guess the make plugin is th
       - liblua5.3-dev
       - unzip
     override-build: |
-      ./configure --prefix=/root/parts/luarocks/install/usr/local
+      ./configure
       make build
-      make install
-    prime:
-      - usr/local/bin
+      snapcraftctl build
 
 apps:
   luarocks:
     command: usr/local/bin/luarocks
+  luarocks-admin:
+    command: usr/local/bin/luarocks-admin


### PR DESCRIPTION
I have created a [snap](https://snapcraft.io) configuration for luarocks. It uses the `classic` confinement, perhaps it could be possible to do this with the `strict` confinement?

The reason for which I am opening this PR as a draft is that I am not getting the snap package to run (building it is fine). Perhaps someone else could try building and running the snap package on their computer to see if it's just me that has misconfigured my snap?

I get the following error after having built the snap (`snapcraft`) and installed it (`snapcraft install luarocks_*.snap --devmode`)

```bash
/snap/luarocks/x1/snap/command-chain/snapcraft-runner: 4: exec: /snap/luarocks/x1/usr/local/bin/luarocks: Permission denied
```

I also tried registering the name, but it seems someone else has already registered it (but not pushed the package). If you decide to go through with this, you could request authorization to use this name as you're the authors of the project. See image.

![luarocks reserved](https://user-images.githubusercontent.com/15460993/73601292-12edb780-455f-11ea-9227-9a8ca2bae428.png)

Fixes #1078