### PR TITLE
Handle quoting at the application level

### DIFF
--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -46,6 +46,10 @@ describe("LuaRocks command line #integration", function()
       it("passes if given a valid path with Lua", function()
          assert.truthy(run.luarocks("--lua-dir=" .. test_env.testing_paths.luadir))
       end)
+
+      it("passes if given a quoted path with Lua", function()
+         assert.truthy(run.luarocks("--lua-dir '" .. test_env.testing_paths.luadir .. "'"))
+      end)
    end)
 
    describe("--lua-version", function()

--- a/src/luarocks/core/dir.lua
+++ b/src/luarocks/core/dir.lua
@@ -4,6 +4,15 @@ local dir = {}
 local require = nil
 --------------------------------------------------------------------------------
 
+local function unquote(c)
+   local first, last = c:sub(1,1), c:sub(-1)
+   if (first == '"' and last == '"') or 
+      (first == "'" and last == "'") then
+      return c:sub(2,-2)
+   end
+   return c
+end
+
 --- Describe a path in a cross-platform way.
 -- Use this function to avoid platform-specific directory
 -- separators in other modules. Removes trailing slashes from
@@ -18,6 +27,9 @@ function dir.path(...)
    while t[1] == "" do
       table.remove(t, 1)
    end
+   for i, c in ipairs(t) do
+      t[i] = unquote(c)
+   end
    return (table.concat(t, "/"):gsub("([^:])/+", "%1/"):gsub("^/+", "/"):gsub("/*$", ""))
 end
 
@@ -29,6 +41,7 @@ end
 function dir.split_url(url)
    assert(type(url) == "string")
    
+   url = unquote(url)
    local protocol, pathname = url:match("^([^:]*)://(.*)")
    if not protocol then
       protocol = "file"


### PR DESCRIPTION
This is done to support Windows. Unix handles quoting at the shell level.

Closes #1173.