### PR TITLE
Update tools.lua - use --help flag versus -h

### DIFF
--- a/src/luarocks/fs/unix/tools.lua
+++ b/src/luarocks/fs/unix/tools.lua
@@ -141,7 +141,7 @@ end
 -- @return boolean: true on success, nil and error message on failure.
 function tools.unzip(zipfile)
    assert(zipfile)
-   local ok, err = fs.is_tool_available(vars.UNZIP, "unzip", "-h")
+   local ok, err = fs.is_tool_available(vars.UNZIP, "unzip", "--help")
    if not ok then
       return nil, err
    end


### PR DESCRIPTION
If you're using busybox, luarocks fails despite unzip being installed. Using the --help flag works in GNU, Busybox, and OSX