### PR TITLE
Add the `--no-install` option to the `make` command

### DIFF
--- a/src/luarocks/build.lua
+++ b/src/luarocks/build.lua
@@ -386,11 +386,13 @@ function build.build_rockspec(rockspec, opts)
       return name, version
    end   
 
+   local dirs, err
    if not opts.no_install then
       if repos.is_installed(name, version) then
          repos.delete_version(name, version, opts.deps_mode)
       end
-      local dirs, err = prepare_install_dirs(name, version)
+
+      dirs, err = prepare_install_dirs(name, version)
       if not dirs then return nil, err end
 
       local rollback = util.schedule_function(function()

--- a/src/luarocks/build.lua
+++ b/src/luarocks/build.lua
@@ -189,7 +189,7 @@ local function prepare_install_dirs(name, version)
    return dirs
 end
 
-local function run_build_driver(rockspec)
+local function run_build_driver(rockspec, no_install)
    local btype = rockspec.build.type
    if btype == "none" then
       return true
@@ -207,7 +207,7 @@ local function run_build_driver(rockspec)
    if not pok or type(driver) ~= "table" then
       return nil, "Failed initializing build back-end for build type '"..btype.."': "..driver
    end
-   local ok, err = driver.run(rockspec)
+   local ok, err = driver.run(rockspec, no_install)
    if not ok then
       return nil, "Build error: " .. err
    end
@@ -407,7 +407,7 @@ function build.build_rockspec(rockspec, opts)
    ok, err = check_macosx_deployment_target(rockspec)
    if not ok then return nil, err end
    
-   ok, err = run_build_driver(rockspec)
+   ok, err = run_build_driver(rockspec, opts.no_install)
    if not ok then return nil, err end
    
    if opts.no_install then

--- a/src/luarocks/build.lua
+++ b/src/luarocks/build.lua
@@ -387,6 +387,7 @@ function build.build_rockspec(rockspec, opts)
    end   
 
    local dirs, err
+   local rollback
    if not opts.no_install then
       if repos.is_installed(name, version) then
          repos.delete_version(name, version, opts.deps_mode)
@@ -395,7 +396,7 @@ function build.build_rockspec(rockspec, opts)
       dirs, err = prepare_install_dirs(name, version)
       if not dirs then return nil, err end
 
-      local rollback = util.schedule_function(function()
+      rollback = util.schedule_function(function()
          fs.delete(path.install_dir(name, version))
          fs.remove_dir_if_empty(path.versions_dir(name))
       end)

--- a/src/luarocks/build/builtin.lua
+++ b/src/luarocks/build/builtin.lua
@@ -149,7 +149,7 @@ end
 -- @param rockspec table: the loaded rockspec.
 -- @return boolean or (nil, string): true if no errors occurred,
 -- nil and an error message otherwise.
-function builtin.run(rockspec)
+function builtin.run(rockspec, no_install)
    assert(rockspec:type() == "rockspec")
    local compile_object, compile_library, compile_static_library
 
@@ -344,19 +344,21 @@ function builtin.run(rockspec)
          ]]
       end
    end
-   for _, mods in ipairs({{ tbl = lua_modules, perms = "read" }, { tbl = lib_modules, perms = "exec" }}) do
-      for name, dest in pairs(mods.tbl) do
-         fs.make_dir(dir.dir_name(dest))
-         ok, err = fs.copy(name, dest, mods.perms)
-         if not ok then
-            return nil, "Failed installing "..name.." in "..dest..": "..err
+   if not no_install then
+      for _, mods in ipairs({{ tbl = lua_modules, perms = "read" }, { tbl = lib_modules, perms = "exec" }}) do
+         for name, dest in pairs(mods.tbl) do
+            fs.make_dir(dir.dir_name(dest))
+            ok, err = fs.copy(name, dest, mods.perms)
+            if not ok then
+               return nil, "Failed installing "..name.." in "..dest..": "..err
+            end
          end
       end
-   end
-   if fs.is_dir("lua") then
-      ok, err = fs.copy_contents("lua", luadir)
-      if not ok then
-         return nil, "Failed copying contents of 'lua' directory: "..err
+      if fs.is_dir("lua") then
+         ok, err = fs.copy_contents("lua", luadir)
+         if not ok then
+            return nil, "Failed copying contents of 'lua' directory: "..err
+         end
       end
    end
    return true

--- a/src/luarocks/build/cmake.lua
+++ b/src/luarocks/build/cmake.lua
@@ -10,7 +10,7 @@ local cfg = require("luarocks.core.cfg")
 -- @param rockspec table: the loaded rockspec.
 -- @return boolean or (nil, string): true if no errors occurred,
 -- nil and an error message otherwise.
-function cmake.run(rockspec)
+function cmake.run(rockspec, no_install)
    assert(rockspec:type() == "rockspec")
    local build = rockspec.build
    local variables = build.variables or {}
@@ -66,7 +66,7 @@ function cmake.run(rockspec)
          return nil, "Failed building."
       end
    end
-   if do_install then
+   if do_install and not no_install then
       if not fs.execute_string(rockspec.variables.CMAKE.." --build build.luarocks --target install --config Release") then
          return nil, "Failed installing."
       end

--- a/src/luarocks/build/command.lua
+++ b/src/luarocks/build/command.lua
@@ -10,7 +10,7 @@ local cfg = require("luarocks.core.cfg")
 -- @param rockspec table: the loaded rockspec.
 -- @return boolean or (nil, string): true if no errors occurred,
 -- nil and an error message otherwise.
-function command.run(rockspec)
+function command.run(rockspec, not_install)
    assert(rockspec:type() == "rockspec")
 
    local build = rockspec.build
@@ -29,7 +29,7 @@ function command.run(rockspec)
          return nil, "Failed building."
       end
    end
-   if build.install_command then
+   if build.install_command and not not_install then
       util.printout(build.install_command)
       if not fs.execute_env(env, build.install_command) then
          return nil, "Failed installing."

--- a/src/luarocks/build/make.lua
+++ b/src/luarocks/build/make.lua
@@ -38,7 +38,7 @@ end
 -- @param rockspec table: the loaded rockspec.
 -- @return boolean or (nil, string): true if no errors occurred,
 -- nil and an error message otherwise.
-function make.run(rockspec)
+function make.run(rockspec, not_install)
    assert(rockspec:type() == "rockspec")
 
    local build = rockspec.build
@@ -86,9 +86,11 @@ function make.run(rockspec)
    if not ok then
       return nil, "Failed building."
    end
-   ok = make_pass(make_cmd, build.install_pass, build.install_target, build.install_variables)
-   if not ok then
-      return nil, "Failed installing."
+   if not not_install then
+      ok = make_pass(make_cmd, build.install_pass, build.install_target, build.install_variables)
+      if not ok then
+         return nil, "Failed installing."
+      end
    end
    return true
 end

--- a/src/luarocks/cmd/build.lua
+++ b/src/luarocks/cmd/build.lua
@@ -129,6 +129,7 @@ function cmd_build.command(args)
       verify = not not args.verify,
       check_lua_versions = not not args.check_lua_versions,
       pin = not not args.pin,
+      no_install = false
    })
 
    if args.sign and not args.pack_binary_rock then

--- a/src/luarocks/cmd/make.lua
+++ b/src/luarocks/cmd/make.lua
@@ -106,7 +106,7 @@ function make.command(args)
       verify = not not args.verify,
       check_lua_versions = not not args.check_lua_versions,
       pin = not not args.pin,
-      no_install = args.no_install
+      no_install = not not args.no_install
    })
 
    if args.sign and not args.pack_binary_rock then

--- a/src/luarocks/cmd/make.lua
+++ b/src/luarocks/cmd/make.lua
@@ -18,6 +18,7 @@ local writer = require("luarocks.manif.writer")
 local cmd = require("luarocks.cmd")
 
 function make.cmd_options(parser)
+   parser:flag("--no-install", "Do not install the rock.")
    parser:flag("--no-doc", "Install the rock without its documentation.")
    parser:flag("--pack-binary-rock", "Do not install rock. Instead, produce a "..
       ".rock file with the contents of compilation in the current directory.")
@@ -104,7 +105,8 @@ function make.command(args)
       branch = args.branch,
       verify = not not args.verify,
       check_lua_versions = not not args.check_lua_versions,
-      pin = not not args.pin
+      pin = not not args.pin,
+      no_install = args.no_install
    })
 
    if args.sign and not args.pack_binary_rock then

--- a/src/luarocks/cmd/make.lua
+++ b/src/luarocks/cmd/make.lua
@@ -113,7 +113,9 @@ function make.command(args)
       return nil, "In the make command, --sign is meant to be used only with --pack-binary-rock"
    end
 
-   if args.pack_binary_rock then
+   if args.no_install then
+      return build.build_rockspec(rockspec, opts)
+   elseif args.pack_binary_rock then
       return pack.pack_binary_rock(name, namespace, rockspec.version, args.sign, function()
          local name, version = build.build_rockspec(rockspec, opts)
          if name and args.no_doc then


### PR DESCRIPTION
Add the --no-install option to the make command to build the rock w/o installing it.

This should improve the workflows using `luarocks make` to build a rock for testing purposes.
The rock will be compiled and _deployed_ in the source folder but not installed.

