### PR TITLE
add CLI variable DEPS_DIR

### DIFF
--- a/src/luarocks/deps.lua
+++ b/src/luarocks/deps.lua
@@ -534,6 +534,8 @@ local function check_external_dependency(name, ext_files, vars, mode, cache)
    local prefixes
    if vars[name .. "_DIR"] then
       prefixes = { vars[name .. "_DIR"] }
+   elseif vars.DEPS_DIR then
+      prefixes = { vars.DEPS_DIR }
    else
       prefixes = cfg.external_deps_dirs
    end


### PR DESCRIPTION
This patch adds a 3rd way to declare a directory path for external dependency.

```luarocks build variables.DEPS_DIR /some/where foo```

When today, the variable name depends of the library required by the rock 

```luarocks build variables.LIBFOO_DIR /some/where foo```

And currently, as `external_deps_dirs` is a table, it cannot be modified by a command `luarocks config ...`.

It could be very convenient in the context of [Buildroot](http://buildroot.org).