### PR TITLE
fix(win32): generate proper temp filename

### DIFF
--- a/src/luarocks/fs/win32.lua
+++ b/src/luarocks/fs/win32.lua
@@ -336,7 +336,7 @@ function win32.make_temp_dir(name_pattern)
 end
 
 function win32.tmpname()
-   return os.getenv("TMP")..os.tmpname()
+   return os.tmpname()
 end
 
 function win32.current_user()

--- a/src/luarocks/fs/win32.lua
+++ b/src/luarocks/fs/win32.lua
@@ -336,7 +336,11 @@ function win32.make_temp_dir(name_pattern)
 end
 
 function win32.tmpname()
-   return os.tmpname()
+   local tmpname = os.tmpname()
+   if tmpname:match("^\\") then
+      tmpname = os.getenv("TMP") .. tmpname
+   end
+   return tmpname
 end
 
 function win32.current_user()


### PR DESCRIPTION
`fs.tmpname()` is currently broken on windows.
On Windows, `os.tmpname()` uses `tmpnam()` that already uses the `TMP` environment variable, if defined (see [ _tempnam, _wtempnam, tmpnam, _wtmpnam](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/tempnam-wtempnam-tmpnam-wtmpnam?view=vs-2019)).