### PR TITLE
feat(persist): add configurable table indentation

### DIFF
--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -479,6 +479,9 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
    defaults.variables.LIB_EXTENSION = defaults.lib_extension
    defaults.variables.OBJ_EXTENSION = defaults.obj_extension
 
+   -- Set the preferred indentation used by `persist.write_table`
+   defaults.table_indentation = "   "
+
    return defaults
 end
 

--- a/src/luarocks/persist.lua
+++ b/src/luarocks/persist.lua
@@ -3,6 +3,7 @@
 -- saving tables into files.
 local persist = {}
 
+local cfg = require("luarocks.core.cfg")
 local core = require("luarocks.core.persist")
 local util = require("luarocks.util")
 local dir = require("luarocks.dir")
@@ -99,7 +100,7 @@ end
 write_table = function(out, tbl, level, field_order)
    out:write("{")
    local sep = "\n"
-   local indentation = "   "
+   local indentation = cfg.table_indentation or "   "
    local indent = true
    local i = 1
    for k, v, sub_order in util.sortedpairs(tbl, field_order) do


### PR DESCRIPTION
`luarocks new_version` writes the new rockspec using `persist.write_table()`. This function uses a default indentation of three spaces per level that is not configurable and might conflict with a project's coding style.

This PR makes the indentation used by `persist.write_table()` configurable.

The default behaviour is unchanged.