### PR TITLE
fs: fix a bug that --verbose raises an exception with nil argument

### DIFF
--- a/src/luarocks/fs.lua
+++ b/src/luarocks/fs.lua
@@ -59,9 +59,9 @@ do
             fs[name] = function(...)
                if fs_is_verbose then
                   local args = { ... }
-                  for i, arg in ipairs(args) do
-                     local pok, v = pcall(string.format, "%q", arg)
-                     args[i] = pok and v or tostring(arg)
+                  for i = 1, #args do
+                     local pok, v = pcall(string.format, "%q", args[i])
+                     args[i] = pok and v or tostring(args[i])
                   end
                   print("fs." .. name .. "(" .. table.concat(args, ", ") .. ")")
                end


### PR DESCRIPTION
For example,
fs.wrap_script(nil, "lua", "all") at
https://github.com/luarocks/luarocks/blob/v3.4.0/src/luarocks/cmd/init.lua#L167
has a nil argument. It raises the following error:

    C:\msys64\home\kou\work\luarocks\src\luarocks\fs.lua:66: invalid value (nil) at index 4 in table for 'concat'
    stack traceback:
            [C]: in function 'table.concat'
            C:\msys64\home\kou\work\luarocks\src\luarocks\fs.lua:66: in function 'luarocks.fs.wrap_script'
            C:\msys64\home\kou\work\luarocks\src\luarocks\cmd\init.lua:148: in function 'luarocks.cmd.init.command'
            (...tail calls...)
            [C]: in function 'xpcall'
            C:\msys64\home\kou\work\luarocks\src\luarocks\cmd.lua:661: in function 'luarocks.cmd.run_command'
            C:/msys64/home/kou/work/luarocks/src/bin/luarocks:35: in main chunk
            [C]: in ?

Because ipairs(args) doesn't iterate all arguments if args has a nil.