### PR TITLE
Add support for MSYS2 + Mingw-w64

### DIFF
--- a/.github/workflows/msys2_mingw_w64.yml
+++ b/.github/workflows/msys2_mingw_w64.yml
@@ -1,0 +1,71 @@
+name: MSYS2 + Mingw-w64
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    # Because the latest LuaSocket can't be built with the latest Mingw-w64.
+    # We need https://github.com/diegonehab/luasocket/pull/312 for this.
+    continue-on-error: true
+    name: ${{ matrix.label }}
+    strategy:
+      fail-fast: false
+      matrix:
+        label:
+          - Lua 5.3
+          - Lua 5.1
+          - LuaJIT 2.0.5
+        include:
+          - label: Lua 5.3
+            lua_interpreter: "lua.exe"
+            lua_version: "5.3"
+            msys2_package: mingw-w64-x86_64-lua
+          - label: Lua 5.1
+            lua_interpreter: "lua5.1.exe"
+            lua_version: "5.1"
+            msys2_package: mingw-w64-x86_64-lua51
+          - label: LuaJIT 2.0.5
+            lua_interpreter: "luajit.exe"
+            lua_version: "5.1"
+            msys2_package: mingw-w64-x86_64-luajit
+    runs-on: windows-2019
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: >-
+            make
+            unzip
+            zip
+            mingw-w64-x86_64-gcc
+            ${{ matrix.msys2_package }}
+      - name: Configure
+        run: |
+          ./configure \
+            --prefix=$HOME/local \
+            --with-lua-interpreter=${{ matrix.lua_interpreter }}
+      - name: Make
+        run: |
+          make
+      - name: Install
+        run: |
+          make install
+      - name: Install dependencies for test
+        run: |
+          set -eux
+          ~/local/bin/luarocks install busted
+          ~/local/bin/luarocks install cluacov
+          ~/local/bin/luarocks install busted-htest
+      - name: Run test
+        run: |
+          lua_modules/bin/busted.bat \
+            -o htest \
+            -v \
+            --exclude-tags=ssh,unix \
+            -Xhelper lua_dir=$(cygpath --windows /mingw64),lua_interpreter=${{ matrix.lua_interpreter }},msys2_mingw_w64

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,9 @@
 /gh-pages
 /wiki
 /lua
+/lua.bat
 /lua_modules
 /luarocks
+/luarocks.bat
 /luarocks-admin
 /.luarocks

--- a/configure
+++ b/configure
@@ -467,6 +467,26 @@ else
    die "Make sure it is installed and available in your PATH."
 fi
 
+dir_separator=$("$LUA_BINDIR/$LUA_INTERPRETER" -e 'print(package.config:sub(1, 1))')
+if [ "$dir_separator" = "\\" ]
+then
+  echo "Lua platform: $(GREEN "Mingw-w64 on MSYS2")"
+  LUA_MSYS2_MINGW_W64=yes
+  LUA_DIR="$(cygpath --windows "$LUA_DIR" | sed -e 's/\\/\\\\/g')"
+  LUA_BINDIR="$(cygpath --windows "$LUA_BINDIR" | sed -e 's/\\/\\\\/g')"
+  if [ "$LUA_INCDIR_SET" = "yes" ]
+  then
+    LUA_INCDIR="$(cygpath --windows "$LUA_INCDIR" | sed -e 's/\\/\\\\/g')"
+  fi
+  if [ "$LUA_LIBDIR_SET" = "yes" ]
+  then
+    LUA_LIBDIR="$(cygpath --windows "$LUA_LIBDIR" | sed -e 's/\\/\\\\/g')"
+  fi
+else
+  echo "Lua platform: $(GREEN "not Mingw-w64 on MSYS2")"
+  LUA_MSYS2_MINGW_W64=no
+fi
+
 # ----------------------------------------
 # Write config
 # ----------------------------------------
@@ -487,6 +507,7 @@ LUA_DIR=$LUA_DIR
 LUA_BINDIR=$LUA_BINDIR
 LUA_INCDIR=$LUA_INCDIR
 LUA_LIBDIR=$LUA_LIBDIR
+LUA_MSYS2_MINGW_W64=$LUA_MSYS2_MINGW_W64
 FORCE_CONFIG=$FORCE_CONFIG
 EOF
 
@@ -501,6 +522,7 @@ echo "Using Lua from.....................: $(GREEN "$LUA_DIR")"
 if [ "$LUA_BINDIR_SET" = "yes" ]; then echo "Lua bin directory..................: $(GREEN "$LUA_BINDIR")" ; fi
 if [ "$LUA_INCDIR_SET" = "yes" ]; then echo "Lua include directory..............: $(GREEN "$LUA_INCDIR")" ; fi
 if [ "$LUA_LIBDIR_SET" = "yes" ]; then echo "Lua lib directory..................: $(GREEN "$LUA_LIBDIR")" ; fi
+echo "Lua is built with Mingw-w64 on MSYS2...: $(GREEN "$LUA_MSYS2_MINGW_W64")"
 echo
 echo "* Type $(BOLD make) and $(BOLD make install):"
 echo "  to install to $prefix as usual."

--- a/spec/build_spec.lua
+++ b/spec/build_spec.lua
@@ -959,7 +959,7 @@ describe("LuaRocks build #unit", function()
          it("automatically extracts the modules and libraries if they are not given and builds against any external dependencies", function()
             local fdir = testing_paths.fixtures_dir
             if test_env.TEST_TARGET_OS == "windows" then
-               if test_env.MINGW then
+               if test_env.MINGW or test_env.MSYS2_MINGW_W64 then
                   os.execute("gcc -shared -o " .. fdir .. "/libfixturedep.dll -Wl,--out-implib," .. fdir .."/libfixturedep.a " .. fdir .. "/fixturedep.c")
                else
                   os.execute("cl " .. fdir .. "\\fixturedep.c /link /export:fixturedep_fn /out:" .. fdir .. "\\fixturedep.dll /implib:" .. fdir .. "\\fixturedep.lib")

--- a/spec/util/test_env.lua
+++ b/spec/util/test_env.lua
@@ -248,6 +248,8 @@ function test_env.set_args()
          test_env.MINGW = true
       elseif argument == "vs" then
          test_env.MINGW = false
+      elseif argument == "msys2_mingw_w64" then
+         test_env.MSYS2_MINGW_W64 = true
       elseif argument:find("^lua_dir=") then
          test_env.LUA_DIR = argument:match("^lua_dir=(.*)$")
       elseif argument:find("^lua_interpreter=") then
@@ -429,7 +431,9 @@ local function hash_environment(path)
       return execute_output("find " .. path .. " -type f -exec stat -f \"%z %N\" {} \\; | md5")
    elseif test_env.TEST_TARGET_OS == "windows" then
       return execute_output("\"" .. Q(test_env.testing_paths.win_tools .. "/find") .. " " .. Q(path)
-         .. " -printf \"%s %p\"\" > temp_sum.txt && certUtil -hashfile temp_sum.txt && del temp_sum.txt")
+         .. " -printf \"%s %p\"\" > temp_sum.txt && "
+         .. "C:\\Windows\\System32\\certUtil -hashfile temp_sum.txt && "
+         .. "del temp_sum.txt")
    end
 end
 
@@ -823,10 +827,14 @@ local function setup_luarocks()
    if test_env.TEST_TARGET_OS == "windows" then
       if test_env.MINGW then
          table.insert(lines, [[SYSTEM = "mingw",]])
+      elseif test_env.MSYS2_MINGW_W64 then
+         table.insert(lines, [[SYSTEM = "msys2_mingw_w64",]])
       else
          table.insert(lines, [[SYSTEM = "windows",]])
       end
-      table.insert(lines, ("WIN_TOOLS = %q,"):format(testing_paths.win_tools))
+      if not test_env.MSYS2_MINGW_W64 then
+         table.insert(lines, ("WIN_TOOLS = %q,"):format(testing_paths.win_tools))
+      end
    end
 
    table.insert(lines, "}")

--- a/src/luarocks/fs/msys2_mingw_w64.lua
+++ b/src/luarocks/fs/msys2_mingw_w64.lua
@@ -1,0 +1,12 @@
+--- MSYS2 + Mingw-w64 implementation of filesystem and platform abstractions.
+local msys2_mingw_w64 = {}
+
+local unix_tools = require("luarocks.fs.unix.tools")
+
+msys2_mingw_w64.zip = unix_tools.zip
+msys2_mingw_w64.unzip = unix_tools.unzip
+msys2_mingw_w64.gunzip = unix_tools.gunzip
+msys2_mingw_w64.bunzip2 = unix_tools.bunzip2
+msys2_mingw_w64.copy_contents = unix_tools.copy_contents
+
+return msys2_mingw_w64

--- a/src/luarocks/fs/unix/tools.lua
+++ b/src/luarocks/fs/unix/tools.lua
@@ -152,13 +152,13 @@ function tools.unzip(zipfile)
    end
 end
 
-local function uncompress(default_ext, program, infile, outfile)
+local function uncompress(default_ext, program, uncompress_flag, infile, outfile)
    assert(type(infile) == "string")
    assert(outfile == nil or type(outfile) == "string")
    if not outfile then
       outfile = infile:gsub("%."..default_ext.."$", "")
    end
-   if fs.execute(fs.Q(program).." -c "..fs.Q(infile).." > "..fs.Q(outfile)) then
+   if fs.execute(fs.Q(program).." "..fs.Q(uncompress_flag).." -c "..fs.Q(infile).." > "..fs.Q(outfile)) then
       return true
    else
       return nil, "failed extracting " .. infile
@@ -171,7 +171,7 @@ end
 -- If not given, name is derived from input file.
 -- @return boolean: true on success; nil and error message on failure.
 function tools.gunzip(infile, outfile)
-   return uncompress("gz", "gunzip", infile, outfile)
+   return uncompress("gz", "gzip", "-d", infile, outfile)
 end
 
 --- Uncompresses a .bz2 file.
@@ -180,7 +180,7 @@ end
 -- If not given, name is derived from input file.
 -- @return boolean: true on success; nil and error message on failure.
 function tools.bunzip2(infile, outfile)
-   return uncompress("bz2", "bunzip2", infile, outfile)
+   return uncompress("bz2", "bzip2", "-d", infile, outfile)
 end
 
 do


### PR DESCRIPTION
Currently, LuaRocks supports:

  * (a) Lua interpreters built for MSYS2 (Lua interpreters depend on msys-2.0.dll).
      (the "msys" platform)

  * (b) Lua interpreters built by MinGW (Lua interpreters don't depend on msys-2.0.dll).
      (the "mingw" platform)

This change adds support for (c) Lua interpreters built as native
Windows application by MSYS2 + Mingw-w64 (Lua interpreters don't
depend on msys-2.0.dll). (the "msys2_mingw_w64" platform)

Here are differences between (a), (b) and (c):

  * (a) can't work without MSYS2 (msys-2.0.dll)
  * (b) can work without MSYS2
  * (c) can work without MSYS2 but is generally used with MSYS2
    because MSYS2 provides useful toolsets such as zip, unzip, wget
    and so on.

This change assumes that users use (c) with MSYS2. This change uses
zip, unzip, wget and so on provided by MSYS2.

MSYS2 has LuaRocks package:
https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-lua-luarocks

It applies a patch to support (c). If this change is merged into
LuaRocks, MSYS2 doesn't need to have a patch for LuaRocks.

CI jobs are added for (c) but they ignore failures. Because the latest
LuaSocket has a problem with the latest Mingw-w64. We need
https://github.com/diegonehab/luasocket/pull/312 to fix this.