### PR TITLE
Add support for MSYS2 + Mingw-w64

### DIFF
--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -45,6 +45,7 @@ local platform_order = {
    "windows",
    "win32",
    "mingw32",
+   "msys2_mingw_w64",
 }
 
 local function detect_sysconfdir()
@@ -70,7 +71,11 @@ end
 
 local function set_confdirs(cfg, platforms, hardcoded_sysconfdir)
    local sysconfdir = os.getenv("LUAROCKS_SYSCONFDIR") or hardcoded_sysconfdir
-   if platforms.windows then
+   local windows_style = platforms.windows
+   if platforms.msys2_mingw_w64 then
+      windows_style = false
+   end
+   if windows_style then
       cfg.home = os.getenv("APPDATA") or "c:"
       cfg.home_tree = cfg.home.."/luarocks"
       cfg.homeconfdir = cfg.home_tree
@@ -167,6 +172,7 @@ local platform_sets = {
    linux = { unix = true, linux = true },
    mingw = { windows = true, win32 = true, mingw32 = true, mingw = true },
    msys = { unix = true, cygwin = true, msys = true },
+   msys2_mingw_w64 = { windows = true, win32 = true, mingw32 = true, mingw = true, msys = true, msys2_mingw_w64 = true },
 }
 
 local function make_platforms(system)
@@ -416,6 +422,29 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
          lib = { "lib?.so", "?.dll", "lib?.dll" },
          include = { "?.h" }
       }
+      if platforms.mingw then
+         -- MSYS2 can build Windows programs that depend on
+         -- msys-2.0.dll (based on Cygwin) but MSYS2 is also designed
+         -- for building native Windows programs by MinGW. These
+         -- programs don't depend on msys-2.0.dll.
+         local pipe = io.popen("cygpath --windows %MINGW_PREFIX%")
+         local mingw_prefix = pipe:read("*l")
+         pipe:close()
+         defaults.external_deps_dirs = { mingw_prefix, "c:/windows/system32" }
+         defaults.makefile = "Makefile"
+         defaults.cmake_generator = "MSYS Makefiles"
+         defaults.local_cache = home.."/.cache/luarocks"
+         defaults.variables.MAKE = "make"
+         defaults.variables.CC = "gcc"
+         defaults.variables.RC = "windres"
+         defaults.variables.LD = "gcc"
+         defaults.variables.MT = nil
+         defaults.variables.AR = "ar"
+         defaults.variables.RANLIB = "ranlib"
+         defaults.variables.LUALIB = "liblua"..lua_version..".dll.a"
+         defaults.variables.CFLAGS = "-O2 -fPIC"
+         defaults.variables.LIBFLAG = "-shared"
+      end
    end
 
    if platforms.bsd then
@@ -600,12 +629,14 @@ function cfg.init(detected, warning)
          -- running from the Development Command prompt for VS 2017
          system = "windows"
       else
-         local fd = io.open("/bin/sh", "r")
-         if fd then
-            fd:close()
+         local msystem = os.getenv("MSYSTEM")
+         if msystem == nil then
+            system = "mingw"
+         elseif msystem == "MSYS" then
             system = "msys"
          else
-            system = "mingw"
+            -- MINGW32 or MINGW64
+            system = "msys2_mingw_w64"
          end
       end
    end


### PR DESCRIPTION
Currently, LuaRocks supports:

  * (a) Lua interpreters built for MSYS2 (Lua interpreters depend on
    msys-2.0.dll).
    (the "msys" platform)

  * (b) Lua interpreters built by MinGW (Lua interpreters don't depend
    on msys-2.0.dll).
    (the "mingw" platform)

This change adds support for (c) Lua interpreters built as native
Windows application by MSYS2 + Mingw-w64 (Lua interpreters don't
depend on msys-2.0.dll). (the "msys2_mingw_w64" platform)

Here are differences between (a), (b) and (c):

  * (a) can't work without MSYS2 (msys-2.0.dll)
  * (b) can work without MSYS2
  * (c) can work without MSYS2 but is generally used with MSYS2
    because MSYS2 provides packages of useful libraries such as libxml2.

This change assumes that users use (c) with MSYS2. But this change
still uses win32/tools provided by LuaRocks not MSYS2.

MSYS2 has LuaRocks package:
https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-lua-luarocks

It applies a patch to support (c). If this change is merged into
LuaRocks, MSYS2 doesn't need to have a patch for LuaRocks.