### PR TITLE
Add changelog for version 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## What's new in LuaRocks 3.5.0
+
+This is a small release:
+
+* Added support for MSYS2 and Mingw-w64
+* Reverted the change in MSVC environment variable set up script
+* Fixes a bug where `--verbose` raised an exception with a nil argument
+* Added proper error messages when lua.h is invalid
+
+
 ## What's new in LuaRocks 3.4.0
 
 ### Features


### PR DESCRIPTION
I just noticed that the changelog doesn't include the changes for version 3.5. I thought that was a bit confusing so I took the liberty to open a PR for it, in the hope that it's useful. I tried to summarize what was said in the announcement email for version 3.5 (which is quoted below, for reference).

-----------------

> Hello list,
> 
> Announcing a new release of LuaRocks, the package manager for Lua. This is a small release, but it contains additions such as added support for MSYS2 + mingw-w64, so I bumped the middle number.
> 
> What's new:
> 
> * support for MSYS2 + Mingw-w64 (by @kou — see https://github.com/luarocks/luarocks/pull/1231 for details)
> * reverted the change in MSVC environment variable set up script which caused problems for Windows users in 3.4.0 (by @hishamhm)
> * fixes a bug where --verbose raised an exception with a nil argument (report by @kou, fix by @daurnimator)
> * add proper error messages when lua.h is invalid. Previously, if LUA_INCDIR was specified but invalid, install and other commands would error without a message, eventually causing a failed assertion in cmd.lua and leaving a hard-to-troubleshoot situation with no information (by @equaa)
> 
> You can find all links for installation at https://luarocks.org — source packages for all supported platforms and binaries for Windows (32 and 64 bit) as well as Linux x86-64 are available.
> 
>  Cheers!
> 
> -- Hisham