### PR TITLE
Add filesystem abstraction for NetBSD

### DIFF
--- a/src/luarocks/fs/netbsd.lua
+++ b/src/luarocks/fs/netbsd.lua
@@ -1,0 +1,14 @@
+--- NetBSD implementation of filesystem and platform abstractions.
+local netbsd = {}
+
+local fs = require("luarocks.fs")
+
+function netbsd.init()
+    local uz=io.open("/usr/bin/unzip", "r")
+    if uz ~= nil then 
+        io.close(uz) 
+        fs.set_tool_available("unzip", true)
+    end
+end
+
+return netbsd


### PR DESCRIPTION
* Add fs abstraction file for NetBSD
* Add init function with verification that the unzip binary is
  available
  
Note that this fixes an issue in NetBSD similar to issues #1022 and #1032 