### PR TITLE
Dynamically detect libdir on Linux

### DIFF
--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -397,6 +397,18 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
          defaults.variables.CFLAGS = defaults.variables.CFLAGS.." -fPIC"
       end
       defaults.web_browser = "xdg-open"
+      if platforms.linux then
+         -- inline code from fs/linux.lua since
+         -- luarocks.fs can't be required here
+         -- (circular dependencies)
+         local fd, _, code = io.open("/usr/lib64", "r")
+         if code ~= 2 then
+            defaults.lib_modules_path = "/lib64/lua/"..lua_version
+         end
+         if fd then
+            fd:close()
+         end
+      end
    end
 
    if platforms.cygwin then


### PR DESCRIPTION
Some Linux distributions (e.g. Fedora, CentOS) put 64-bit libraries
in `/usr/lib64` rather than `/usr/lib`. On such systems `luarocks`
should use `lib64` rather than `lib`.

PS the implementation here is really suboptimal; ideally I can set this when `LUA_LIBDIR` is populated:


Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/luarocks/luarocks/1277)
<!-- Reviewable:end -->
