### PR TITLE
Fix issue with old manifests, more thorough checking

### DIFF
--- a/spec/remove_spec.lua
+++ b/spec/remove_spec.lua
@@ -2,6 +2,7 @@ local test_env = require("spec.util.test_env")
 local lfs = require("lfs")
 local run = test_env.run
 local testing_paths = test_env.testing_paths
+local env_variables = test_env.env_variables
 
 test_env.unload_luarocks()
 
@@ -9,7 +10,9 @@ local extra_rocks = {
    "/abelhas-1.1-1.src.rock",
    "/copas-2.0.1-1.src.rock",
    "/coxpcall-1.16.0-1.src.rock",
-   "/coxpcall-1.16.0-1.rockspec"
+   "/coxpcall-1.16.0-1.rockspec",
+   "/luafilesystem-1.7.0-1.src.rock",
+   "/luafilesystem-1.6.3-2.src.rock",
 }
 
 describe("luarocks remove #integration", function()
@@ -79,6 +82,36 @@ describe("luarocks remove #integration", function()
          local output = run.luarocks("remove --force-fast coxpcall")
          assert.is.falsy(lfs.attributes(testing_paths.testing_sys_rocks .. "/coxpcall"))
          assert.is.falsy(output:find("Checking stability of dependencies"))
+      end)
+
+      it("restores old versions", function()
+         assert.is_true(run.luarocks_bool("install luafilesystem 1.6.3"))
+         assert.is.truthy(lfs.attributes(testing_paths.testing_sys_tree .. "/lib/lua/"..env_variables.LUA_VERSION.."/lfs."..test_env.lib_extension))
+
+         if test_env.TEST_TARGET_OS ~= "windows" then
+            local fd = io.open(testing_paths.testing_sys_tree .. "/lib/lua/"..env_variables.LUA_VERSION.."/lfs."..test_env.lib_extension, "r")
+            assert(fd:read("*a"):match("LuaFileSystem 1.6.3", 1, true))
+            fd:close()
+         end
+
+         assert.is_true(run.luarocks_bool("install luafilesystem 1.7.0 --keep"))
+         assert.is.truthy(lfs.attributes(testing_paths.testing_sys_tree .. "/lib/lua/"..env_variables.LUA_VERSION.."/lfs."..test_env.lib_extension))
+         assert.is.truthy(lfs.attributes(testing_paths.testing_sys_tree .. "/lib/lua/"..env_variables.LUA_VERSION.."/luafilesystem_1_6_3_2-lfs."..test_env.lib_extension))
+
+         if test_env.TEST_TARGET_OS ~= "windows" then
+            local fd = io.open(testing_paths.testing_sys_tree .. "/lib/lua/"..env_variables.LUA_VERSION.."/lfs."..test_env.lib_extension, "r")
+            assert(fd:read("*a"):match("LuaFileSystem 1.7.0", 1, true))
+            fd:close()
+         end
+
+         assert.is_true(run.luarocks_bool("remove luafilesystem 1.7.0"))
+         assert.is.truthy(lfs.attributes(testing_paths.testing_sys_tree .. "/lib/lua/"..env_variables.LUA_VERSION.."/lfs."..test_env.lib_extension))
+
+         if test_env.TEST_TARGET_OS ~= "windows" then
+            local fd = io.open(testing_paths.testing_sys_tree .. "/lib/lua/"..env_variables.LUA_VERSION.."/lfs."..test_env.lib_extension, "r")
+            assert(fd:read("*a"):match("LuaFileSystem 1.6.3", 1, true))
+            fd:close()
+         end
       end)
    end)
 

--- a/src/luarocks/cmd/build.lua
+++ b/src/luarocks/cmd/build.lua
@@ -165,8 +165,10 @@ function cmd_build.command(args)
       util.printout()
    else
       if (not args.keep) and not cfg.keep_other_versions then
-         local ok, err = remove.remove_other_versions(name, version, args.force, args.force_fast)
+         local ok, err, warn = remove.remove_other_versions(name, version, args.force, args.force_fast)
          if not ok then
+            return nil, err
+         elseif warn then
             util.printerr(err)
          end
       end

--- a/src/luarocks/cmd/install.lua
+++ b/src/luarocks/cmd/install.lua
@@ -195,8 +195,12 @@ local function install_rock_file(filename, opts)
    end
 
    if (not opts.keep) and not cfg.keep_other_versions then
-      local ok, err = remove.remove_other_versions(name, version, opts.force, opts.force_fast)
-      if not ok then util.printerr(err) end
+      local ok, err, warn = remove.remove_other_versions(name, version, opts.force, opts.force_fast)
+      if not ok then
+         return nil, err
+      elseif warn then
+         util.printerr(err)
+      end
    end
 
    writer.check_dependencies(nil, opts.deps_mode)

--- a/src/luarocks/cmd/make.lua
+++ b/src/luarocks/cmd/make.lua
@@ -142,8 +142,12 @@ function make.command(args)
       end
 
       if (not args.keep) and not cfg.keep_other_versions then
-         local ok, err = remove.remove_other_versions(name, version, args.force, args.force_fast)
-         if not ok then util.printerr(err) end
+         local ok, err, warn = remove.remove_other_versions(name, version, args.force, args.force_fast)
+         if not ok then
+            return nil, err
+         elseif warn then
+            util.printerr(warn)
+         end
       end
 
       writer.check_dependencies(nil, deps.get_deps_mode(args))

--- a/src/luarocks/cmd/purge.lua
+++ b/src/luarocks/cmd/purge.lua
@@ -62,8 +62,10 @@ function purge.command(args)
       for version, _ in util.sortedpairs(versions, sort) do
          if args.old_versions then
             util.printout("Keeping "..package.." "..version.."...")
-            local ok, err = remove.remove_other_versions(package, version, args.force, args.force_fast)
+            local ok, err, warn = remove.remove_other_versions(package, version, args.force, args.force_fast)
             if not ok then
+               util.printerr(err)
+            elseif warn then
                util.printerr(err)
             end
             break

--- a/src/luarocks/repos.lua
+++ b/src/luarocks/repos.lua
@@ -248,6 +248,14 @@ end
 local function check_spot_if_available(name, version, deploy_type, file_path)
    local item_type, item_name = get_provided_item(deploy_type, file_path)
    local cur_name, cur_version = manif.get_current_provider(item_type, item_name)
+
+   -- older versions of LuaRocks (< 3) registered "foo.init" files as "foo"
+   -- (which caused problems, so that behavior was changed). But look for that
+   -- in the manifest anyway for backward compatibility.
+   if not cur_name and deploy_type == "lua" and item_name:match("%.init$") then
+      cur_name, cur_version = manif.get_current_provider(item_type, (item_name:gsub("%.init$", "")))
+   end
+
    if (not cur_name)
       or (name < cur_name)
       or (name == cur_name and (version == cur_version

--- a/src/luarocks/repos.lua
+++ b/src/luarocks/repos.lua
@@ -607,7 +607,7 @@ function repos.delete_version(name, version, deps_mode, quick)
             local next_name, next_version = manif.get_next_provider("command", item_name)
             if next_name then
                add_to_double_checks(double_checks, next_name, next_version)
-               local next_paths = get_deploy_paths(next_name, next_version, "lua", file_path, repo)
+               local next_paths = get_deploy_paths(next_name, next_version, "bin", file_path, repo)
                table.insert(renames, { src = next_paths.v, dst = next_paths.nv, suffix = cfg.wrapper_suffix })
             end
          end

--- a/src/luarocks/repos.lua
+++ b/src/luarocks/repos.lua
@@ -523,7 +523,14 @@ function repos.delete_version(name, version, deps_mode, quick)
    assert(type(deps_mode) == "string")
 
    local rock_manifest, load_err = manif.load_rock_manifest(name, version)
-   if not rock_manifest then return nil, load_err end
+   if not rock_manifest then
+      if not quick then
+         local writer = require("luarocks.manif.writer")
+         writer.remove_from_manifest(name, version, nil, deps_mode)
+         return nil, "rock_manifest file not found for "..name.." "..version.." - removed entry from the manifest"
+      end
+      return nil, load_err
+   end
 
    local repo = cfg.root_dir
    local renames = {}


### PR DESCRIPTION
A series of improvements resulting from the investigation triggered by #1276:

* search for "foo" in manifest when processing "foo.init" - Older versions of LuaRocks (< 3) registered "foo.init" files as "foo" (which caused problems, so that behavior was changed). But look for that in the manifest anyway for backward compatibility.
* double-check that all files from a rock are installed: ensure that `luarocks` fails if an installation does not successfully deploy all files registered in the `rock_manifest`.
  * checks that either an active or inactive version of each file is present on installation (we may be installing an older, inactive version that can only be loaded with `luarocks.loader()`)
  * checks that when removing a version, the files from other versions thet are not being removed are still retained
  * checks that when installing without `--keep`, all files from the version being installed are now active (this is the most relevant behavior)
    * running the test suite with this check added actually uncovered a bug affecting bin/ entries!
* remove entry from manifest if rock is already missing - If rock_manifest could not be found, the entry in manifest is unusable: without the list of files from rock_manifest, we can't scan the repository to remove files. This means the entry in the repo manifest is a leftover from an incomplete removal. Remove the entry from the repo manifest.
