### PR TITLE
XDG Base Directory

### DIFF
--- a/src/luarocks/cmd.lua
+++ b/src/luarocks/cmd.lua
@@ -85,7 +85,7 @@ do
             replace_tree(args, root_dir)
          end
       elseif args["local"] then
-         if not cfg.home_tree then
+         if os.getenv("USER") == "root" then
             return nil, "The --local flag is meant for operating in a user's home directory.\n"..
                "You are running as a superuser, which is intended for system-wide operation.\n"..
                "To force using the superuser's home, use --tree explicitly."
@@ -642,7 +642,7 @@ function cmd.run_command(description, commands, external_namespace, ...)
    end
 
    -- if running as superuser, use system cache dir
-   if not cfg.home_tree then
+   if os.getenv("USER") == "root" then
       cfg.local_cache = dir.path(fs.system_cache_dir(), "luarocks")
    end
 

--- a/src/luarocks/cmd.lua
+++ b/src/luarocks/cmd.lua
@@ -85,7 +85,7 @@ do
             replace_tree(args, root_dir)
          end
       elseif args["local"] then
-         if os.getenv("USER") == "root" then
+         if fs.is_superuser() then
             return nil, "The --local flag is meant for operating in a user's home directory.\n"..
                "You are running as a superuser, which is intended for system-wide operation.\n"..
                "To force using the superuser's home, use --tree explicitly."
@@ -642,7 +642,7 @@ function cmd.run_command(description, commands, external_namespace, ...)
    end
 
    -- if running as superuser, use system cache dir
-   if os.getenv("USER") == "root" then
+   if fs.is_superuser() then
       cfg.local_cache = dir.path(fs.system_cache_dir(), "luarocks")
    end
 

--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -385,7 +385,8 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
       }
       defaults.export_path_separator = ":"
       defaults.wrapper_suffix = ""
-      defaults.local_cache = home.."/.cache/luarocks"
+      local xdg_cache_home = os.getenv("XDG_CACHE_HOME") or home.."/.cache"
+      defaults.local_cache = xdg_cache_home.."/luarocks"
       if not defaults.variables.CFLAGS:match("-fPIC") then
          defaults.variables.CFLAGS = defaults.variables.CFLAGS.." -fPIC"
       end

--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -86,8 +86,8 @@ local function set_confdirs(cfg, platforms, hardcoded_sysconfdir)
          sysconfdir = detect_sysconfdir()
       end
       cfg.home = os.getenv("HOME") or ""
-      cfg.home_tree = (os.getenv("USER") ~= "root") and cfg.home.."/.luarocks"
-      cfg.homeconfdir = cfg.home.."/.luarocks"
+      cfg.home_tree = cfg.home.."/.luarocks"
+      cfg.homeconfdir = cfg.home_tree
       cfg.sysconfdir = sysconfdir or "/etc/luarocks"
    end
 end

--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -72,23 +72,16 @@ end
 
 local function set_confdirs(cfg, platforms, hardcoded_sysconfdir)
    local sysconfdir = os.getenv("LUAROCKS_SYSCONFDIR") or hardcoded_sysconfdir
-   local windows_style = platforms.windows
-   if platforms.msys2_mingw_w64 then
-      windows_style = false
-   end
-   if windows_style then
+   if platforms.windows and not platforms.msys2_mingw_w64 then
       cfg.home = os.getenv("APPDATA") or "c:"
       cfg.home_tree = cfg.home.."/luarocks"
       cfg.homeconfdir = cfg.home_tree
       cfg.sysconfdir = sysconfdir or ((os.getenv("PROGRAMFILES") or "c:") .. "/luarocks")
    else
-      if not sysconfdir then
-         sysconfdir = detect_sysconfdir()
-      end
       cfg.home = os.getenv("HOME") or ""
       cfg.home_tree = cfg.home.."/.luarocks"
       cfg.homeconfdir = cfg.home_tree
-      cfg.sysconfdir = sysconfdir or "/etc/luarocks"
+      cfg.sysconfdir = sysconfdir or detect_sysconfdir() or "/etc/luarocks"
    end
 end
 

--- a/src/luarocks/fs/lua.lua
+++ b/src/luarocks/fs/lua.lua
@@ -1034,6 +1034,10 @@ function fs_lua.current_user()
    return posix.getpwuid(posix.geteuid()).pw_name
 end
 
+function fs_lua.is_superuser()
+   return false
+end
+
 -- This call is not available on all systems, see #677
 if posix.mkdtemp then
 

--- a/src/luarocks/fs/unix.lua
+++ b/src/luarocks/fs/unix.lua
@@ -179,6 +179,10 @@ function unix.current_user()
    return os.getenv("USER")
 end
 
+function unix.is_superuser()
+   return os.getenv("USER") == "root"
+end
+
 function unix.export_cmd(var, val)
    return ("export %s='%s'"):format(var, val)
 end

--- a/src/luarocks/fs/win32.lua
+++ b/src/luarocks/fs/win32.lua
@@ -351,6 +351,10 @@ function win32.current_user()
    return os.getenv("USERNAME")
 end
 
+function win32.is_superuser()
+   return false
+end
+
 function win32.export_cmd(var, val)
    return ("SET %s=%s"):format(var, val)
 end


### PR DESCRIPTION
Hello again :wave:

This PR makes LuaRocks follow the XDG Base Directory specification. Info about this can be found here:
* https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
* https://wiki.archlinux.org/index.php/XDG_Base_Directory

The jist of it is mainly that LuaRocks respects the environment variables `XDG_CACHE_HOME` and `XDG_CONFIG_HOME` and uses those directories accordingly. This is done in an backwards compatible manner, so for users that have their config file `~/.luarocks/` this will not have an affect at all. This does however allow users to place their config in `XDG_CONFIG_HOME/luarocks/` instead, should the wish to.

I've not yet added tests or written any documentation, but I'll be sure to do that if this PR gets traction.

Resolves #1086.
Resolves #1219.