### PR TITLE
use mirrors when downloading rocks even if manifest succeeds

### DIFF
--- a/src/luarocks/build.lua
+++ b/src/luarocks/build.lua
@@ -135,7 +135,7 @@ local function process_dependencies(rockspec, opts)
          end
       end
    end
-   local ok, err, errcode = deps.fulfill_dependencies(rockspec, "dependencies", opts.deps_mode, opts.verify)
+   ok, err, errcode = deps.fulfill_dependencies(rockspec, "dependencies", opts.deps_mode, opts.verify)
    if err then
       return nil, err, errcode
    end

--- a/src/luarocks/cmd.lua
+++ b/src/luarocks/cmd.lua
@@ -165,6 +165,7 @@ end
 -- @param exitcode number: the exitcode to use
 local function die(message, exitcode)
    assert(type(message) == "string", "bad error, expected string, got: " .. type(message))
+   assert(exitcode == nil or type(exitcode) == "number", "bad error, expected number, got: " .. type(exitcode) .. " - " .. tostring(exitcode))
    util.printerr("\nError: "..message)
 
    local ok, err = xpcall(util.run_scheduled_functions, error_handler)

--- a/src/luarocks/cmd/build.lua
+++ b/src/luarocks/cmd/build.lua
@@ -94,9 +94,9 @@ local function do_build(name, namespace, version, opts)
    end
 
    if url:match("%.rockspec$") then
-      local rockspec, err, errcode = fetch.load_rockspec(url, nil, opts.verify)
+      local rockspec, err = fetch.load_rockspec(url, nil, opts.verify)
       if not rockspec then
-         return nil, err, errcode
+         return nil, err
       end
       return build.build_rockspec(rockspec, opts)
    end
@@ -138,11 +138,11 @@ function cmd_build.command(args)
 
    if args.pack_binary_rock then
       return pack.pack_binary_rock(args.rock, args.namespace, args.version, args.sign, function()
-         local name, version, errcode = do_build(args.rock, args.namespace, args.version, opts)
+         local name, version = do_build(args.rock, args.namespace, args.version, opts)
          if name and args.no_doc then
             util.remove_doc_dir(name, version)
          end
-         return name, version, errcode
+         return name, version
       end)
    end
 
@@ -151,9 +151,9 @@ function cmd_build.command(args)
       return nil, err, cmd.errorcodes.PERMISSIONDENIED
    end
 
-   local name, version, errcode = do_build(args.rock, args.namespace, args.version, opts)
+   local name, version = do_build(args.rock, args.namespace, args.version, opts)
    if not name then
-      return nil, version, errcode
+      return nil, version
    end
 
    if args.no_doc then

--- a/src/luarocks/cmd/remove.lua
+++ b/src/luarocks/cmd/remove.lua
@@ -54,15 +54,16 @@ function cmd_remove.command(args)
       if not name then return nil, "Invalid "..rock_type.." filename: "..filename end
    end
 
-   local results = {}
    name = name:lower()
+
+   local results = {}
    search.local_manifest_search(results, cfg.rocks_dir, queries.new(name, args.namespace, version))
    if not results[name] then
       local rock = util.format_rock_name(name, args.namespace, version)
       return nil, "Could not find rock '"..rock.."' in "..path.rocks_tree_to_string(cfg.root_dir)
    end
 
-   local ok, err = remove.remove_search_results(results, name, deps_mode, args.force, args.force_fast)
+   ok, err = remove.remove_search_results(results, name, deps_mode, args.force, args.force_fast)
    if not ok then
       return nil, err
    end

--- a/src/luarocks/download.lua
+++ b/src/luarocks/download.lua
@@ -18,7 +18,9 @@ local function get_file(filename)
          return nil, err
       end
    else
-      return fetch.fetch_url(filename)
+      -- discard third result
+      local ok, err = fetch.fetch_url(filename)
+      return ok, err
    end
 end
 

--- a/src/luarocks/manif.lua
+++ b/src/luarocks/manif.lua
@@ -105,7 +105,7 @@ function manif.load_manifest(repo_url, lua_version, versioned_only)
    else
       local err, errcode
       for _, filename in ipairs(filenames) do
-         pathname, err, errcode, from_cache = fetch.fetch_caching(dir.path(repo_url, filename))
+         pathname, err, errcode, from_cache = fetch.fetch_caching(dir.path(repo_url, filename), "no_mirror")
          if pathname then
             break
          end

--- a/src/luarocks/remove.lua
+++ b/src/luarocks/remove.lua
@@ -18,11 +18,13 @@ local queries = require("luarocks.queries")
 -- of the given list, or an array of strings in "name/version" format.
 local function check_dependents(name, versions, deps_mode)
    local dependents = {}
-   local blacklist = {}
-   blacklist[name] = {}
+
+   local skip_set = {}
+   skip_set[name] = {}
    for version, _ in pairs(versions) do
-      blacklist[name][version] = true
+      skip_set[name][version] = true
    end
+
    local local_rocks = {}
    local query_all = queries.all()
    search.local_manifest_search(local_rocks, cfg.rocks_dir, query_all)
@@ -31,13 +33,14 @@ local function check_dependents(name, versions, deps_mode)
       for rock_version, _ in pairs(rock_versions) do
          local rockspec, err = fetch.load_rockspec(path.rockspec_file(rock_name, rock_version))
          if rockspec then
-            local _, missing = deps.match_deps(rockspec.dependencies, rockspec.rocks_provided, blacklist, deps_mode)
+            local _, missing = deps.match_deps(rockspec.dependencies, rockspec.rocks_provided, skip_set, deps_mode)
             if missing[name] then
                table.insert(dependents, { name = rock_name, version = rock_version })
             end
          end
       end
    end
+
    return dependents
 end
 


### PR DESCRIPTION
Up until now, LuaRocks would check whether to use a mirror in the first download operation, when it fetches the manifest. Once the server (luarocks.org or one of its default mirrors) was chosen, it would stick with it for the rest of the command.

The resulting behavior was that if the manifest fails to load, it switches to a mirror and continues from there. But if the manifest fetches ok and the then actual rock download fails, it would up, instead of trying that in a mirror as well.

This PR changes the behavior to make it retry every download on a mirror whenever the base URL matches one configured in `cfg.rocks_servers`. The original behavior was satisfactory if there was complete downtime in the main server, but this new behavior should make the CLI much more resilient with regard to intermittent failures.

Fixes #1299.
