### PR TITLE
Add issue templates for bugs and enhancements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bugs
+about: Bugs and unintented behaviour
+labels: 'bug'
+
+---
+
+### Please read the following before submitting:
+- Please do NOT submit bug reports for questions. Ask questions in the [Gitter
+  chat-room](https://gitter.im/luarocks/luarocks).
+- Please do NOT submit duplicate bug reports. Look through the [issue
+  tracker](https://github.com/luarocks/luarocks/issues) before submitting.
+
+### Please fill out the following:
+- **Platform:**
+  - Windows/Linux/MacOS.
+
+- **LuaRocks version:**
+  - `luarocks --version`
+
+- **Configuration file:**
+  - Please try to produce with the default configuration.
+  - If you cannot reproduce with the default configuration, please try to find
+    the minimal configuration to reproduce.
+  - Upload the config to a pastebin such as gist.github.com.
+
+- **LuaRocks output from when the issue occurred:**
+  - Use the `--verbose` flag.
+
+- **Description:**
+  - The steps you took in plain English to reproduce the problem.

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,11 @@
+---
+name: Enhancements
+about: New functionality
+labels: 'enhancement'
+
+---
+
+### Please fill out the following:
+- **Description:**
+  - Please describe in plain English what the enhancement is and what the use case
+    is.


### PR DESCRIPTION
Hey again :wave:

The issue tracker does unfortunately contain quite a lot of low-quality
issues. I think issue templates can improve this for the future.

Adapted from these templates:

  https://github.com/swaywm/sway/tree/master/.github/ISSUE_TEMPLATE

What do you think, @hishamhm?