### PR TITLE
fix configuration for OpenBSD

### DIFF
--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -480,6 +480,11 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
 
    if platforms.openbsd then
       defaults.arch = "openbsd-"..target_cpu
+      defaults.gcc_rpath = false
+      defaults.variables.CC = os.getenv("CC") or "cc"
+      defaults.variables.CFLAGS = os.getenv("CFLAGS") or defaults.variables.CFLAGS
+      defaults.variables.LD = defaults.variables.CC
+      defaults.variables.LIBFLAG = (os.getenv("LDFLAGS") or "").." -shared"
    end
 
    if platforms.netbsd then


### PR DESCRIPTION
Hello,

I'd like to port luarocks to OpenBSD.  With this PR I'm able to install and use various libraries (tried with luasockets, dkjson, lua-lsp, luaffifb) -- I'm just a lua beginner thought.

I've seen that for other OS there is an implementation of filesystem and platform abstractions, is this needed for all OSes?  Or there are other interfaces that are better be implemented?

Thanks!