### PR TITLE
Prevent creation of directory named '-p' on Windows

### DIFF
--- a/src/luarocks/fs/win32/tools.lua
+++ b/src/luarocks/fs/win32/tools.lua
@@ -36,7 +36,7 @@ end
 function tools.make_dir(directory)
    assert(directory)
    directory = dir.normalize(directory)
-   fs.execute_quiet(vars.MKDIR.." -p ", directory)
+   fs.execute_quiet(vars.MKDIR, directory)
    if not fs.is_dir(directory) then
       return false, "failed making directory "..directory
    end


### PR DESCRIPTION
`tools.make_dir` used `mkdir -p <name>` while `-p` [is not an existing switch](https://docs.microsoft.com/windows-server/administration/windows-commands/mkdir) on Windows. The switch is also not necessary because plain `mkdir` on Windows also creates intermediate directories.