### PR TITLE
always use https for cloning git repository

### DIFF
--- a/src/luarocks/fetch/git.lua
+++ b/src/luarocks/fetch/git.lua
@@ -112,7 +112,8 @@ function git.get_sources(rockspec, extract, dest_dir, depth)
    local ok, err = fs.change_dir(store_dir)
    if not ok then return nil, err end
 
-   local command = {fs.Q(git_cmd), "clone", depth or "--depth=1", rockspec.source.url, module}
+   local https_source_url = "https://" .. rockspec.source.url
+   local command = {fs.Q(git_cmd), "clone", depth or "--depth=1", https_source_url, module}
    local tag_or_branch = rockspec.source.tag or rockspec.source.branch
    -- If the tag or branch is explicitly set to "master" in the rockspec, then
    -- we can avoid passing it to Git since it's the default.


### PR DESCRIPTION
Github deprecating the usage of `git:` (among other things) https://github.blog/2021-09-01-improving-git-protocol-security-github/

I suspect this is not the best solution, but hopefully good enough to start the discussion. Or should this even not be concern of Luarocks and be handled in  individual rock files?