### PR TITLE
[fix] The misleading `--pin` option

### DIFF
--- a/src/luarocks/cmd/build.lua
+++ b/src/luarocks/cmd/build.lua
@@ -36,7 +36,7 @@ function cmd_build.add_to_parser(parser)
       "rockspec. Allows to specify a different branch to fetch. Particularly "..
       'for "dev" rocks.')
       :argname("<name>")
-   parser:flag("--pin", "Create a luarocks.lock file listing the exact "..
+   cmd:flag("--pin", "Create a luarocks.lock file listing the exact "..
       "versions of each dependency found for this rock (recursively), "..
       "and store it in the rock's directory. "..
       "Ignores any existing luarocks.lock file in the rock's sources.")

--- a/src/luarocks/cmd/install.lua
+++ b/src/luarocks/cmd/install.lua
@@ -43,6 +43,10 @@ function install.add_to_parser(parser)
       "and report if it is available for another Lua version.")
    util.deps_mode_option(cmd)
    cmd:flag("--no-manifest", "Skip creating/updating the manifest")
+   cmd:flag("--pin", "If the installed rock is a Lua module, create a "..
+      "luarocks.lock file listing the exact versions of each dependency found for "..
+      "this rock (recursively), and store it in the rock's directory. "..
+      "Ignores any existing luarocks.lock file in the rock's sources.")
    -- luarocks build options
    parser:flag("--pack-binary-rock"):hidden(true)
    parser:option("--branch"):hidden(true)


### PR DESCRIPTION
Hello,

This is my attempt at fixing the issue I reported earlier #1389.

Thank you, @daurnimator, for your input on the build command part.

I also tried to document the ability to use this option with the `install` command. I for example used it to generate the `luarocks.lock` file of my module after adding dependencies in the `.rockspec` file : `./luarocks install --deps-only --pin testmodule-1-1.rockspec`.

However, I don't know if the description I wrote is correct. Any feedback is welcomed! :)

Fixes #1389 