### PR TITLE
builtin: always respect CC, CFLAGS, LDFLAGS

### DIFF
--- a/src/luarocks/build/builtin.lua
+++ b/src/luarocks/build/builtin.lua
@@ -157,6 +157,10 @@ function builtin.run(rockspec, no_install)
    local variables = rockspec.variables
    local checked_lua_h = false
 
+   for _, var in ipairs{ "CC", "CFLAGS", "LDFLAGS" } do
+      variables[var] = os.getenv(var) or variables[var] or ""
+   end
+
    local function add_flags(extras, flag, flags)
       if flags then
          if type(flags) ~= "table" then
@@ -182,7 +186,7 @@ function builtin.run(rockspec, no_install)
          add_flags(extras, "-l%s", libraries)
          extras[#extras+1] = dir.path(variables.LUA_LIBDIR, variables.LUALIB)
          extras[#extras+1] = "-l" .. (variables.MSVCRT or "m")
-         local ok = execute(variables.LD.." "..variables.LIBFLAG, "-o", library, unpack(extras))
+         local ok = execute(variables.LD.." "..variables.LDFLAGS, variables.LIBFLAG, "-o", library, unpack(extras))
          return ok
       end
       --[[ TODO disable static libs until we fix the conflict in the manifest, which will take extending the manifest format.
@@ -250,7 +254,7 @@ function builtin.run(rockspec, no_install)
             extras[#extras+1] = "-L"..variables.LUA_LIBDIR
             extras[#extras+1] = "-llua"
          end
-         return execute(variables.LD.." "..variables.LIBFLAG, "-o", library, unpack(extras))
+         return execute(variables.LD.." "..variables.LDFLAGS, variables.LIBFLAG, "-o", library, unpack(extras))
       end
       compile_static_library = function(library, objects, libraries, libdirs, name)  -- luacheck: ignore 211
          local ok = execute(variables.AR, "rc", library, unpack(objects))

--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -476,19 +476,17 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
    if platforms.freebsd then
       defaults.arch = "freebsd-"..target_cpu
       defaults.gcc_rpath = false
-      defaults.variables.CC = os.getenv("CC") or "cc"
-      defaults.variables.CFLAGS = os.getenv("CFLAGS") or defaults.variables.CFLAGS
+      defaults.variables.CC = "cc"
       defaults.variables.LD = defaults.variables.CC
-      defaults.variables.LIBFLAG = (os.getenv("LDFLAGS") or "").." -shared"
+      defaults.variables.LIBFLAG = "-shared"
    end
 
    if platforms.openbsd then
       defaults.arch = "openbsd-"..target_cpu
       defaults.gcc_rpath = false
-      defaults.variables.CC = os.getenv("CC") or "cc"
-      defaults.variables.CFLAGS = os.getenv("CFLAGS") or defaults.variables.CFLAGS
+      defaults.variables.CC = "cc"
       defaults.variables.LD = defaults.variables.CC
-      defaults.variables.LIBFLAG = (os.getenv("LDFLAGS") or "").." -shared"
+      defaults.variables.LIBFLAG = "-shared"
    end
 
    if platforms.netbsd then


### PR DESCRIPTION
There were already workarounds in place for some platforms.
This should make the behavior consistent.

Fixes #429.