### PR TITLE
configure: Use shell '#' and '%' magic instead of sed

### DIFF
--- a/configure
+++ b/configure
@@ -211,8 +211,8 @@ search_interpreter() {
 
 while [ -n "$1" ]
 do
-   value="$(echo "$1" | sed 's/[^=]*.\(.*\)/\1/')"
-   key="$(echo "$1" | sed 's/=.*//')"
+   key=${1%%=*}
+   value=${1#*=}
    if echo "$value" | grep "~" >/dev/null 2>/dev/null
    then
       echo


### PR DESCRIPTION
Mainly a style preference... Also has the benefit of not calling an external process for this.