### PR TITLE
Strip quotes for tools in paths on Windows

### DIFF
--- a/src/luarocks/fs/lua.lua
+++ b/src/luarocks/fs/lua.lua
@@ -126,7 +126,8 @@ function fs_lua.is_tool_available(tool_cmd, tool_name)
 
       -- if it looks like the tool has a pathname, try that first
       if tool_cmd_no_args:match("[/\\]") then
-         local fd = io.open(tool_cmd_no_args, "r")
+         local tool_cmd_no_args_normalized = dir.path(tool_cmd_no_args)
+         local fd = io.open(tool_cmd_no_args_normalized, "r")
          if fd then
             fd:close()
             ok = true


### PR DESCRIPTION
As mentioned by @erw7 in
https://github.com/luarocks/luarocks/issues/1443#issuecomment-1483816481,
quotes is required when using io.popen but causes problems when using
io.iopen. This makes luarocks unable to find its own md5sum.exe it is
shipped with.

Fixes https://github.com/luarocks/luarocks/issues/1443
Fixes https://github.com/neovim/neovim/issues/22752

Co-authored-by: erw7 <erw7.github@gmail.com>
