### PR TITLE
update domain name of mirror (luafr.org -> loadk.com)

### DIFF
--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -200,7 +200,7 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
          {
            "https://luarocks.org",
            "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/",
-           "https://luafr.org/luarocks/",
+           "https://loadk.com/luarocks/",
          }
       },
       disabled_servers = {},


### PR DESCRIPTION
It is the same server, but due to registrar-related changes I probably won't renew the luafr.org domain name. OTOH loadk.com is paid through 2026 and almost certainly not going anywhere after than. :)