### PR TITLE
luajit: ignore extra version info in jit.version

### DIFF
--- a/src/luarocks/util.lua
+++ b/src/luarocks/util.lua
@@ -457,7 +457,8 @@ do
 
       local ljv
       if cfg.lua_version == "5.1" then
-         ljv = util.popen_read(Q(cfg.variables["LUA_BINDIR"] .. "/" .. cfg.lua_interpreter) .. ' -e "io.write(tostring(jit and jit.version:gsub([[^%S+ ]], [[]])))"')
+         -- Ignores extra version info for custom builds, e.g. "LuaJIT 2.1.0-beta3 some-other-version-info"  
+         ljv = util.popen_read(Q(cfg.variables["LUA_BINDIR"] .. "/" .. cfg.lua_interpreter) .. ' -e "io.write(tostring(jit and jit.version:gsub([[^%S+ (%S+).*]], [[%1]])))"')
          if ljv == "nil" then
             ljv = nil
          end


### PR DESCRIPTION
Ignore any extra version info in jit.version when separated by a space.

A normal LuaJIT jit.version string looks like "LuaJIT 2.1.0-beta3". Since official LuaJIT releases have all but stopped, various forks continue to use the same version for all forks.

This change allows forks and patched rebuilds to add additional version information at the end of the string without breaking luarocks version detection, e.g. "LuaJIT 2.1.0-beta3 some-extra-version-info".
