### PR TITLE
Add missing `-R` flag to `cp` command in `fs.copy()`

### DIFF
--- a/src/luarocks/fs/unix/tools.lua
+++ b/src/luarocks/fs/unix/tools.lua
@@ -57,7 +57,7 @@ end
 -- plus an error message.
 function tools.copy(src, dest, perm)
    assert(src and dest)
-   if fs.execute(vars.CP.." -PR "..src..dest) then
+   if fs.execute(vars.CP.." -PR ", src, dest) then
       if perm then
          if fs.is_dir(dest) then
             dest = dir.path(dest, dir.base_name(src))

--- a/src/luarocks/fs/unix/tools.lua
+++ b/src/luarocks/fs/unix/tools.lua
@@ -57,7 +57,7 @@ end
 -- plus an error message.
 function tools.copy(src, dest, perm)
    assert(src and dest)
-   if fs.execute(vars.CP, src, dest) then
+   if fs.execute(vars.CP.." -PR "..src..dest) then
       if perm then
          if fs.is_dir(dest) then
             dest = dir.path(dest, dir.base_name(src))


### PR DESCRIPTION
Fixes #1496

I also added the `-P` flag, I don't think it is required to copy symbolic links?