### PR TITLE
admin: remove now works with the file protocol

### DIFF
--- a/src/luarocks/admin/cmd/remove.lua
+++ b/src/luarocks/admin/cmd/remove.lua
@@ -37,9 +37,6 @@ local function remove_files_from_server(refresh, rockfiles, server, upload_serve
    if not local_cache then
       return nil, protocol
    end
-   if protocol ~= "rsync" then
-      return nil, "This command requires 'rsync', check your configuration."
-   end
 
    local ok, err = fs.change_dir(at)
    if not ok then return nil, err end
@@ -67,6 +64,17 @@ local function remove_files_from_server(refresh, rockfiles, server, upload_serve
    writer.make_manifest(local_cache, "one", true)
    util.printout("Updating index.html...")
    index.make_index(local_cache)
+
+   if protocol == "file" then
+       local cmd = cfg.variables.RSYNC.." "..cfg.variables.RSYNCFLAGS.." --delete "..local_cache.."/ ".. server_path.."/"
+       util.printout(cmd)
+       fs.execute(cmd)
+       return true
+   end
+
+   if protocol ~= "rsync" then
+      return nil, "This command requires 'rsync', check your configuration."
+   end
 
    local srv, path = server_path:match("([^/]+)(/.+)")
    local cmd = cfg.variables.RSYNC.." "..cfg.variables.RSYNCFLAGS.." --delete -e ssh "..local_cache.."/ "..user.."@"..srv..":"..path.."/"


### PR DESCRIPTION
`admin add` can add rockspec using the file protocol without any problems: ./bin/luarocks-admin add testapp-scm-1.rockspec --server '/tmp/rocks/orig'

But deletion only works using the rsync protocol.
This patch adds deletion via file protocol.