### PR TITLE
Fix crash when using --tree on musl

### DIFF
--- a/src/luarocks/cmd.lua
+++ b/src/luarocks/cmd.lua
@@ -83,6 +83,9 @@ do
          if not named then
             local root_dir = fs.absolute_name(args.tree)
             replace_tree(args, root_dir)
+            if (args.deps_mode or cfg.deps_mode) ~= "order" then
+               table.insert(cfg.rocks_trees, 1, { name = "arg", root = root_dir } )
+            end
          end
       elseif args["local"] then
          if fs.is_superuser() then


### PR DESCRIPTION
This PR addresses the crash described in #1549 and adds the value passed to the `--tree` argument to `cfg.rocks_trees`.
Tested and working on `alpine:edge` running `luarocks-5.1` v3.9.2.