### PR TITLE
Don't use floats to parse the Lua version

### DIFF
--- a/src/luarocks/deps.lua
+++ b/src/luarocks/deps.lua
@@ -652,10 +652,8 @@ function deps.scan_deps(results, manifest, name, version, deps_mode)
 end
 
 local function lua_h_exists(d, luaver)
-   local n = tonumber(luaver)
-   local major = math.floor(n)
-   local minor = (n - major) * 10
-   local luanum = math.floor(major * 100 + minor)
+   local major, minor = luaver:match("(%d+)%.(%d+)")
+   local luanum = ("%s%02d"):format(major, tonumber(minor))
 
    local lua_h = dir.path(d, "lua.h")
    local fd = io.open(lua_h)


### PR DESCRIPTION
Hi,

I installed luarocks in Alpine on WSL and this happens:

```
> luarocks-5.4 build

Error: Lua header found at /usr/include/lua5.4 does not match Lua version 5.4. You may want to override this by configuring LUA_INCDIR.
```

because:

```
> cat a.lua
local n = tonumber("5.4")
local major = math.floor(n)
local minor = (n - major) * 10
print(major, minor)
local luanum = math.floor(major * 100 + minor)
print(luanum)

local major, minor = string.match("5.4", "(%d+)%.(%d+)")
print(string.format("%s%02d", major, tonumber(minor)))
> lua a.lua
5       3.9999999999964
503
504
```

No idea why this happens but it doesn't happen on any other installs I have and this fixes it