### PR TITLE
fix: `build.install_command` doesn't execute on windows

### DIFF
--- a/src/luarocks/fs/lua.lua
+++ b/src/luarocks/fs/lua.lua
@@ -54,7 +54,7 @@ function fs_lua.is_writable(file)
    return result
 end
 
-local function quote_args(command, ...)
+function fs_lua.quote_args(command, ...)
    local out = { command }
    local args = pack(...)
    for i=1, args.n do
@@ -74,7 +74,7 @@ end
 -- otherwise.
 function fs_lua.execute(command, ...)
    assert(type(command) == "string")
-   return fs.execute_string(quote_args(command, ...))
+   return fs.execute_string(fs.quote_args(command, ...))
 end
 
 --- Run the given command, quoting its arguments, silencing its output.
@@ -88,19 +88,19 @@ end
 function fs_lua.execute_quiet(command, ...)
    assert(type(command) == "string")
    if cfg.verbose then -- omit silencing output
-      return fs.execute_string(quote_args(command, ...))
+      return fs.execute_string(fs.quote_args(command, ...))
    else
-      return fs.execute_string(fs.quiet(quote_args(command, ...)))
+      return fs.execute_string(fs.quiet(fs.quote_args(command, ...)))
    end
 end
 
-function fs.execute_env(env, command, ...)
+function fs_lua.execute_env(env, command, ...)
    assert(type(command) == "string")
    local envstr = {}
    for var, val in pairs(env) do
       table.insert(envstr, fs.export_cmd(var, val))
    end
-   return fs.execute_string(table.concat(envstr, "\n") .. "\n" .. quote_args(command, ...))
+   return fs.execute_string(table.concat(envstr, "\n") .. "\n" .. fs.quote_args(command, ...))
 end
 
 local tool_available_cache = {}

--- a/src/luarocks/fs/win32.lua
+++ b/src/luarocks/fs/win32.lua
@@ -35,6 +35,16 @@ function win32.quiet_stderr(cmd)
    return cmd.." 2> NUL"
 end
 
+function win32.execute_env(env, command, ...)
+   assert(type(command) == "string")
+   local cmdstr = {}
+   for var, val in pairs(env) do
+      table.insert(cmdstr, fs.export_cmd(var, val))
+   end
+   table.insert(cmdstr, fs.quote_args(command, ...))
+   return fs.execute_string(table.concat(cmdstr, " & "))
+end
+
 -- Split path into drive, root and the rest.
 -- Example: "c:\\hello\\world" becomes "c:" "\\" "hello\\world"
 -- if any part is missing from input, it becomes an empty string.


### PR DESCRIPTION
This PR fixes #1568.

The issue was that `os.execute()` on windows does not support multiple commands seperated by newlines.
Instead it's required to use the `cmd.exe`-syntax: `command1 & command2`.

This is now implemented in `win32.execute_env()`.