### PR TITLE
fix: sysdetect: prefer interpreter to avoid multiarch shell on macOS

### DIFF
--- a/src/luarocks/core/sysdetect.lua
+++ b/src/luarocks/core/sysdetect.lua
@@ -398,7 +398,7 @@ function sysdetect.detect(input_file)
       if interp then
          if interp:match(dirsep) then
             -- interpreter path is absolute
-            table.insert(files, interp)
+            table.insert(files, 1, interp)
          else
             for d in (os.getenv("PATH") or ""):gmatch("[^"..PATHsep.."]+") do
                table.insert(files, d .. dirsep .. interp)


### PR DESCRIPTION
Thanks @RunsFor for the suggested workaround!

Fixes #1529.