### PR TITLE
fix: install build_dependencies on the correct Lua version

### DIFF
--- a/src/luarocks/path.lua
+++ b/src/luarocks/path.lua
@@ -219,13 +219,14 @@ function path.use_tree(tree)
    cfg.deploy_bin_dir = path.deploy_bin_dir(tree)
    cfg.deploy_lua_dir = path.deploy_lua_dir(tree)
    cfg.deploy_lib_dir = path.deploy_lib_dir(tree)
+end
 
-   -- TODO Do we want LuaRocks itself to use whatever tree is in use?
-   -- package.path = dir.path(path.deploy_lua_dir(tree), "?.lua") .. ";"
-   --             .. dir.path(path.deploy_lua_dir(tree), "?/init.lua") .. ";"
-   --             .. package.path
-   -- package.cpath = dir.path(path.deploy_lib_dir(tree), "?." .. cfg.lib_extension) .. ";"
-   --              .. package.cpath
+function path.add_to_package_paths(tree)
+   package.path = dir.path(path.deploy_lua_dir(tree), "?.lua") .. ";"
+               .. dir.path(path.deploy_lua_dir(tree), "?/init.lua") .. ";"
+               .. package.path
+   package.cpath = dir.path(path.deploy_lib_dir(tree), "?." .. cfg.lib_extension) .. ";"
+                .. package.cpath
 end
 
 --- Get the namespace of a locally-installed rock, if any.


### PR DESCRIPTION
When installing build dependencies, do so for the Lua version on which the LuaRocks program is actually running, and not the one selected by the user via config or `--lua-version`.

To do that, we temporarily flip the user-selected Lua version. It's a hacky approach because we have to do this by flipping a bunch of global config settings, and we may be missing some entries.

This definitely needs a better solution, but this is what can be done somewhat easily in the current architecture. A full solution needs to address have several complications (e.g. if you have a build dependency that needs to be compiled, it will require C headers for another version of LuaRocks, and the binary might be compiled with a different Lua version than the one the developer has set up in their machine.)

Fixes #1509.
Fixes #1521.