### PR TITLE
fix(build): add some validation to the build table

### DIFF
--- a/src/luarocks/build/builtin.lua
+++ b/src/luarocks/build/builtin.lua
@@ -321,7 +321,13 @@ function builtin.run(rockspec, no_install)
          local sources = info.sources
          if info[1] then sources = info end
          if type(sources) == "string" then sources = {sources} end
+         if type(sources) ~= "table" then
+            return nil, "error in rockspec: module '" .. name .. "' entry has no 'sources' list"
+         end
          for _, source in ipairs(sources) do
+            if type(source) ~= "string" then
+               return nil, "error in rockspec: module '" .. name .. "' does not specify source correctly."
+            end
             local object = source:gsub("%.[^.]*$", "."..cfg.obj_extension)
             if not object then
                object = source.."."..cfg.obj_extension


### PR DESCRIPTION
LuaRocks does not validate the contents of the build table because each backend defines it on this own. These validations should be enough to address #1477, but ideally each bundled `build` backend should have its own validator like the one on `luarocks.type.rockspec`.

Fixes #1477.