### PR TITLE
feat(builtin): inherit inc and libdirs from external_dependencies

### DIFF
--- a/src/luarocks/build/builtin.lua
+++ b/src/luarocks/build/builtin.lua
@@ -279,11 +279,12 @@ function builtin.run(rockspec, no_install)
    local luadir = path.lua_dir(rockspec.name, rockspec.version)
    local libdir = path.lib_dir(rockspec.name, rockspec.version)
 
+   local autolibs, autoincdirs, autolibdirs = autoextract_libs(rockspec.external_dependencies, rockspec.variables)
+
    if not build.modules then
       if rockspec:format_is_at_least("3.0") then
-         local libs, incdirs, libdirs = autoextract_libs(rockspec.external_dependencies, rockspec.variables)
          local install, copy_directories
-         build.modules, install, copy_directories = builtin.autodetect_modules(libs, incdirs, libdirs)
+         build.modules, install, copy_directories = builtin.autodetect_modules(autolibs, autoincdirs, autolibdirs)
          build.install = build.install or install
          build.copy_directories = build.copy_directories or copy_directories
       else
@@ -326,7 +327,7 @@ function builtin.run(rockspec, no_install)
             if not object then
                object = source.."."..cfg.obj_extension
             end
-            ok = compile_object(object, source, info.defines, info.incdirs)
+            ok = compile_object(object, source, info.defines, info.incdirs or autoincdirs)
             if not ok then
                return nil, "Failed compiling object "..object
             end
@@ -339,7 +340,7 @@ function builtin.run(rockspec, no_install)
             if not ok then return nil, err end
          end
          lib_modules[module_name] = dir.path(libdir, module_name)
-         ok = compile_library(module_name, objects, info.libraries, info.libdirs, name)
+         ok = compile_library(module_name, objects, info.libraries, info.libdirs or autolibdirs, name)
          if not ok then
             return nil, "Failed compiling module "..module_name
          end


### PR DESCRIPTION
If a rockspec has external_dependencies but the module entry does not specify incdirs or libdirs, then autoextract those values from external_dependencies and apply it to the module entry.

Hopefully this will improve compatibility of existing rockspecs that did not fully specify their incdirs and libdirs, such as https://github.com/brimworks/lua-yajl/blob/078e48147e89d34b8224a07129675aa9b5820630/rockspecs/lua-yajl-2.0-1.rockspec

Fixes #1239.