### PR TITLE
fix: do not attempt setting exec permissions for folders on Windows

### DIFF
--- a/src/luarocks/fs/lua.lua
+++ b/src/luarocks/fs/lua.lua
@@ -373,9 +373,11 @@ function fs_lua.make_dir(directory)
          if not ok then
             return false, err
          end
-         ok, err = fs.set_permissions(path, "exec", "all")
-         if not ok then
-            return false, err
+         if cfg.is_platform("unix") then
+            ok, err = fs.set_permissions(path, "exec", "all")
+            if not ok then
+               return false, err
+            end
          end
       elseif mode ~= "directory" then
          return false, path.." is not a directory"


### PR DESCRIPTION
Not sure of what are the circumstances that make this cause problems on Windows, but running this shouldn't be necessary on Windows, since the concept of "execute permissions for directories means traversal permissions" is a Unixism.

Fixes #991.