### PR TITLE
normalize project dir

### DIFF
--- a/src/luarocks/cmd.lua
+++ b/src/luarocks/cmd.lua
@@ -220,7 +220,7 @@ do
             local try = "."
             for _ = 1, 10 do -- FIXME detect when root dir was hit instead
                if util.exists(try .. "/.luarocks") and util.exists(try .. "/lua_modules") then
-                  return try, false
+                  return dir.normalize(try), false
                elseif util.exists(try .. "/.luarocks-no-project") then
                   break
                end


### PR DESCRIPTION
Avoid showing things like `/foo/bar/../.././lua_modules` when running `luarocks path`.