### PR TITLE
when picking a default dependency dir, look for lib/ first

### DIFF
--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -319,8 +319,8 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
       defaults.local_cache = localappdata.."/LuaRocks/Cache"
       defaults.web_browser = "start"
 
-      defaults.external_deps_subdirs.lib = { "", "lib", "bin" }
-      defaults.runtime_external_deps_subdirs.lib = { "", "lib", "bin" }
+      defaults.external_deps_subdirs.lib = { "lib", "", "bin" }
+      defaults.runtime_external_deps_subdirs.lib = { "lib", "", "bin" }
       defaults.link_lua_explicitly = true
       defaults.fs_use_modules = false
    end
@@ -494,8 +494,8 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
 
       -- Homebrew
       table.insert(defaults.external_deps_dirs, "/usr/local/opt")
-      defaults.external_deps_subdirs.lib = { "", "lib", }
-      defaults.runtime_external_deps_subdirs.lib = { "", "lib", }
+      defaults.external_deps_subdirs.lib = { "lib", "" }
+      defaults.runtime_external_deps_subdirs.lib = { "lib", "" }
       table.insert(defaults.external_deps_patterns.lib, 1, "/?/lib/lib?.dylib")
       table.insert(defaults.runtime_external_deps_patterns.lib, 1, "/?/lib/lib?.dylib")
    end
@@ -505,11 +505,11 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
 
       local gcc_arch = util.popen_read("gcc -print-multiarch 2>/dev/null")
       if gcc_arch and gcc_arch ~= "" then
-         defaults.external_deps_subdirs.lib = { "lib", "lib/" .. gcc_arch, "lib64" }
-         defaults.runtime_external_deps_subdirs.lib = { "lib", "lib/" .. gcc_arch, "lib64" }
+         defaults.external_deps_subdirs.lib = { "lib/" .. gcc_arch, "lib64", "lib" }
+         defaults.runtime_external_deps_subdirs.lib = { "lib/" .. gcc_arch, "lib64", "lib" }
       else
-         defaults.external_deps_subdirs.lib = { "lib", "lib64" }
-         defaults.runtime_external_deps_subdirs.lib = { "lib", "lib64" }
+         defaults.external_deps_subdirs.lib = { "lib64", "lib" }
+         defaults.runtime_external_deps_subdirs.lib = { "lib64", "lib" }
       end
    end
 

--- a/src/luarocks/deps.lua
+++ b/src/luarocks/deps.lua
@@ -446,7 +446,6 @@ local function check_external_dependency_at(prefix, name, ext_files, vars, dirs,
       else
          paths = { dir.path(prefix, dirdata.subdir) }
       end
-      dirdata.dir = paths[1]
       local file_or_files = ext_files[dirdata.testfile]
       if file_or_files then
          local files = {}
@@ -511,6 +510,17 @@ local function check_external_dependency_at(prefix, name, ext_files, vars, dirs,
          end
          if not found then
             return nil, dirname, dirdata.testfile
+         end
+      else
+         -- When we have a set of subdir suffixes, look for one that exists.
+         -- For these reason, we now put "lib" ahead of "" on Windows in our
+         -- default set.
+         dirdata.dir = paths[1]
+         for _, p in ipairs(paths) do
+            if fs.exists(p) then
+               dirdata.dir = p
+               break
+            end
          end
       end
    end


### PR DESCRIPTION
When a rockspec specifies `external_dependencies` but those don't define a `library` entry, we don't have a way to check for the various possible `external_deps_subdirs` to find the one that contains the library. (But people really should specify a `library` entry there if they're linking the library!)

Previously, we were just picking the first one from the list. On Windows, this meant that sometimes setting `MY_DEPENDENCY_DIR` would not be sufficient if the library was under `$MY_DEPENDENCY_DIR/lib`, because "" was picked first. We now improve the heuristic by putting "lib" first on the list and checking if it exists.

I'm still keeping "bin" in the end of the list, because I think this is less common that a flat directory structure on Windows, so "lib" covers the Unix-like trees and "" covers flat trees (I don't remember why have "bin" as a library subdir on Windows, but if it's there then we must have seen it in the wild!) This means that "bin" will never get auto-picked by this heuristic, but it will be available for the cases where `library` _is_ set.

While I'm at it, I also flipped the order of some Unix entries, so that this heuristic for these kind of rockspecs gets a nicer behavior on Unix systems that have things like `/usr/lib64` and `/usr/lib/<platform>` as well.

Fixes #1041.