### PR TITLE
improve and simplify Lua interpreter search

### DIFF
--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -60,7 +60,7 @@ describe("LuaRocks command line #integration", function()
 
       it("warns but continues if given an invalid version", function()
          local output = run.luarocks("--lua-version=1.0")
-         assert.match("Warning: Lua 1.0 interpreter not found", output, 1, true)
+         assert.match("LUA *: %(not found%)", output)
          assert.match("Version%s*:%s*1.0", output)
       end)
 

--- a/src/luarocks/cmd/init.lua
+++ b/src/luarocks/cmd/init.lua
@@ -106,10 +106,6 @@ function init.command(args)
 
    util.title("Initializing project '" .. args.name .. "' for Lua " .. cfg.lua_version .. " ...")
 
-   util.printout("Checking your Lua installation ...")
-   if not cfg.lua_found then
-      return nil, "Lua installation is not found."
-   end
    local ok, err = deps.check_lua_incdir(cfg.variables)
    if not ok then
       return nil, err

--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -787,7 +787,7 @@ function cfg.init(detected, warning)
    -- if only cfg.variables.LUA is given in config files,
    -- derive LUA_BINDIR and LUA_DIR from them.
    if cfg.variables.LUA and not cfg.variables.LUA_BINDIR then
-      cfg.variables.LUA_BINDIR = cfg.variables.LUA:gsub("^(.*)[/\\][^/\\]*$")
+      cfg.variables.LUA_BINDIR = cfg.variables.LUA:match("^(.*)[/\\][^/\\]*$")
       if not cfg.variables.LUA_DIR then
          cfg.variables.LUA_DIR = cfg.variables.LUA_BINDIR:gsub("[/\\]bin$", "") or cfg.variables.LUA_BINDIR
       end

--- a/src/luarocks/deps.lua
+++ b/src/luarocks/deps.lua
@@ -663,7 +663,7 @@ local function lua_h_exists(d, luaver)
       return nil, "Lua header found at " .. d .. " does not match Lua version " .. luaver .. ". You may want to override this by configuring LUA_INCDIR.", "dependency", 2
    end
 
-   return nil, "Failed finding Lua header files. You may need to install them or configure LUA_INCDIR.", "dependency", 1
+   return nil, "Failed finding Lua header files (searched at " .. d .. "). You may need to install them or configure LUA_INCDIR.", "dependency", 1
 end
 
 local function find_lua_incdir(prefix, luaver, luajitver)
@@ -711,7 +711,7 @@ function deps.check_lua_incdir(vars)
       return nil, err
    end
 
-   return nil, "Failed finding Lua header files. You may need to install them or configure LUA_INCDIR.", "dependency"
+   return nil, "Failed finding Lua headers; neither LUA_DIR or LUA_INCDIR are set. You may need to install them or configure LUA_INCDIR.", "dependency"
 end
 
 function deps.check_lua_libdir(vars)
@@ -732,6 +732,7 @@ function deps.check_lua_libdir(vars)
    }
    if ljv then
       table.insert(libnames, 1, "luajit-" .. cfg.lua_version)
+      table.insert(libnames, 2, "luajit")
    end
    local cache = {}
    local save_LUA_INCDIR = vars.LUA_INCDIR

--- a/src/luarocks/util.lua
+++ b/src/luarocks/util.lua
@@ -434,6 +434,10 @@ do
       end
       cfg.cache.luajit_version_checked = true
 
+      if not cfg.variables.LUA then
+         return nil
+      end
+
       local ljv
       if cfg.lua_version == "5.1" then
          -- Ignores extra version info for custom builds, e.g. "LuaJIT 2.1.0-beta3 some-other-version-info"


### PR DESCRIPTION
The goal is to reduce confusion when multiple related `LUA_*` variables and flags are set by the user (see #906 for an example). We currently have a way too complex system of configurability + auto-detection which leads to a hard-to-predict flowchart of behaviors.

In short, this PR contains two major changes:

* do not proceed with commands if interpreter is not found
* begin retiring LUA_DIR and LUA_BINDIR, and promote LUA as the main way to setup the interpreter location (from which we derive the rest).

Closes #906.
