### PR TITLE
fix: let runtime detection handle LUALIB filename

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -339,7 +339,7 @@ local function look_for_link_libraries(directory)
 	-- MinGW does not generate .lib, nor needs it to link, but MSVC does,
 	-- so .lib must be listed first to ensure they are found first if present,
 	-- to prevent MSVC trying to link to a .dll, which won't work.
-	local names = {S"lua$LUA_VERSION.lib", S"lua$LUA_SHORTV.lib", S"lua$LUA_VERSION.dll", S"lua$LUA_SHORTV.dll", "liblua.dll.a"}
+	local names = {S"lua$LUA_VERSION.lib", S"lua$LUA_SHORTV.lib", S"liblua$LUA_SHORTV.a", S"lua$LUA_VERSION.dll", S"lua$LUA_SHORTV.dll", "liblua.dll.a"}
 	local directories
 	if vars.LUA_LIBDIR then
 		directories = {vars.LUA_LIBDIR}
@@ -1151,7 +1151,6 @@ if USE_MINGW and vars.LUA_RUNTIME == "MSVCRT" then
 else
 	f:write("    MSVCRT = '"..vars.LUA_RUNTIME.."',\n")
 end
-f:write(S"    LUALIB = '$LUA_LIBNAME',\n")
 if USE_MINGW then
         f:write(S[[
     CC = $MINGW_CC,

--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -293,14 +293,13 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
       defaults.variables.LD = os.getenv("LINK") or "link"
       defaults.variables.MT = os.getenv("MT") or "mt"
       defaults.variables.AR = os.getenv("AR") or "lib"
-      defaults.variables.LUALIB = "lua"..lua_version..".lib"
       defaults.variables.CFLAGS = os.getenv("CFLAGS") or "/nologo /MD /O2"
       defaults.variables.LDFLAGS = os.getenv("LDFLAGS")
       defaults.variables.LIBFLAG = "/nologo /dll"
 
       defaults.external_deps_patterns = {
          bin = { "?.exe", "?.bat" },
-         lib = { "?.lib", "?.dll", "lib?.dll" },
+         lib = { "?.lib", "lib?.lib", "?.dll", "lib?.dll" },
          include = { "?.h" }
       }
       defaults.runtime_external_deps_patterns = {
@@ -443,7 +442,6 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
          defaults.variables.MT = os.getenv("MT") or nil
          defaults.variables.AR = os.getenv("AR") or "ar"
          defaults.variables.RANLIB = os.getenv("RANLIB") or "ranlib"
-         defaults.variables.LUALIB = "liblua"..lua_version..".dll.a"
 
          defaults.variables.CFLAGS = os.getenv("CFLAGS") or "-O2 -fPIC"
          if not defaults.variables.CFLAGS:match("-fPIC") then


### PR DESCRIPTION
This should be more flexible than hardcoding a value that may become incorrect once people reconfigure their LuaRocks to point to another Lua distribution, especially on Windows.

Fixes #905.