### PR TITLE
fix: prevent LuaRocks from blocking lfs from removal on Windows

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -1163,6 +1163,7 @@ if USE_MINGW then
 end
 f:write("}\n")
 f:write("verbose = false   -- set to 'true' to enable verbose output\n")
+f:write("fs_use_modules = false   -- prevent LuaRocks itself from using installed modules and blocking their files from removal \n")
 f:close()
 
 print(S"Created LuaRocks config file: $CONFIG_FILE")


### PR DESCRIPTION
Prevent LuaRocks itself from using installed modules and blocking their files from removal.

This is not an issue on luarocks.exe because its own copy of lfs is statically linked. We need to eventually switch to using that always, but for now this is a workable solution.

Fixes #1428.