### PR TITLE
fix: on windows environment variables are passed with trailing space

### DIFF
--- a/src/luarocks/fs/win32.lua
+++ b/src/luarocks/fs/win32.lua
@@ -349,7 +349,7 @@ function win32.is_superuser()
 end
 
 function win32.export_cmd(var, val)
-   return ("SET %s=%s"):format(var, val)
+   return ("SET %s"):format(fs.Q(var.."="..val))
 end
 
 function win32.system_cache_dir()


### PR DESCRIPTION
This fix addresses a mistake I've made in the PR #1569. `cmd`s `SET key=value` syntax assigns to key everything behind `=` until the next `&`, even if it contains spaces:
```shell
> cmd /C type NUL && SET FOO=BAR & lua -e "print(string.format('%q', os.getenv 'FOO'))"                                                 
"BAR "
```
Either one quotes the whole argument:
```shell
> cmd /C type NUL && SET "FOO=BAR" & lua -e "print(string.format('%q', os.getenv 'FOO'))"
"BAR"
```
Or we remove the extra spaces:
```shell
cmd /C type NUL && SET FOO=BAR&lua -e "print(string.format('%q', os.getenv 'FOO'))"                                                   
"BAR"
```
I opted for the first option, which appears safer, considering that we quote the argument via `fs.Q`.