### PR TITLE
fix: don't try to lock when using --pack-binary-rock

### DIFF
--- a/src/luarocks/cmd.lua
+++ b/src/luarocks/cmd.lua
@@ -735,7 +735,7 @@ function cmd.run_command(description, commands, external_namespace, ...)
                            and (" - failed to force the lock" .. (err and ": " .. err or ""))
                            or  " - use --force-lock to overwrite the lock"
          die("command '" .. args.command .. "' " ..
-             "requires exclusive access to " .. cfg.root_dir ..
+             "requires exclusive access to " .. path.root_dir(cfg.root_dir) ..
              try_force, cmd.errorcodes.LOCK)
       end
    end

--- a/src/luarocks/cmd.lua
+++ b/src/luarocks/cmd.lua
@@ -728,7 +728,7 @@ function cmd.run_command(description, commands, external_namespace, ...)
    local cmd_mod = cmd_modules[args.command]
 
    local lock
-   if cmd_mod.needs_lock then
+   if cmd_mod.needs_lock and cmd_mod.needs_lock(args) then
       lock, err = fs.lock_access(path.root_dir(cfg.root_dir), args.force_lock)
       if not lock then
          local try_force = args.force_lock

--- a/src/luarocks/cmd/build.lua
+++ b/src/luarocks/cmd/build.lua
@@ -180,6 +180,11 @@ function cmd_build.command(args)
    return name, version
 end
 
-cmd_build.needs_lock = true
+cmd_build.needs_lock = function(args)
+   if args.pack_binary_rock then
+      return false
+   end
+   return true
+end
 
 return cmd_build

--- a/src/luarocks/cmd/init.lua
+++ b/src/luarocks/cmd/init.lua
@@ -212,6 +212,6 @@ function init.command(args)
    return true
 end
 
-init.needs_lock = true
+init.needs_lock = function() return true end
 
 return init

--- a/src/luarocks/cmd/install.lua
+++ b/src/luarocks/cmd/install.lua
@@ -255,6 +255,11 @@ function install.command(args)
    end
 end
 
-install.needs_lock = true
+install.needs_lock = function(args)
+   if args.pack_binary_rock then
+      return false
+   end
+   return true
+end
 
 return install

--- a/src/luarocks/cmd/make.lua
+++ b/src/luarocks/cmd/make.lua
@@ -155,6 +155,11 @@ function make.command(args)
    end
 end
 
-make.needs_lock = true
+make.needs_lock = function(args)
+   if args.pack_binary_rock then
+      return false
+   end
+   return true
+end
 
 return make

--- a/src/luarocks/cmd/purge.lua
+++ b/src/luarocks/cmd/purge.lua
@@ -73,6 +73,6 @@ function purge.command(args)
    return writer.make_manifest(cfg.rocks_dir, "one")
 end
 
-purge.needs_lock = true
+purge.needs_lock = function() return true end
 
 return purge

--- a/src/luarocks/cmd/remove.lua
+++ b/src/luarocks/cmd/remove.lua
@@ -72,6 +72,6 @@ function cmd_remove.command(args)
    return true
 end
 
-cmd_remove.needs_lock = true
+cmd_remove.needs_lock = function() return true end
 
 return cmd_remove


### PR DESCRIPTION
Also, don't crash when root_dir is a table.

Fixes #1626.