### PR TITLE
tests: use paths with spaces when testing on Windows

### DIFF
--- a/spec/util/test_env.lua
+++ b/spec/util/test_env.lua
@@ -720,7 +720,13 @@ local function create_testing_paths(suffix)
    paths.fixtures_repo_dir = dir_path(base_dir, "spec", "fixtures", "a_repo")
    paths.gpg_dir           = dir_path(base_dir, "spec", "fixtures", "gpg")
 
-   local testrun_dir = dir_path(base_dir, "testrun")
+   local testrun_dir
+   if test_env.TEST_TARGET_OS == "windows" then
+      testrun_dir = dir_path(base_dir, "test run")
+   else
+      testrun_dir = dir_path(base_dir, "testrun")
+   end
+
    paths.testrun_dir           = testrun_dir
    paths.testing_lrprefix      = dir_path(testrun_dir, "testing_lrprefix-" .. suffix)
    paths.testing_tree          = dir_path(testrun_dir, "testing-" .. suffix)

--- a/src/luarocks/fs/win32.lua
+++ b/src/luarocks/fs/win32.lua
@@ -349,7 +349,7 @@ function win32.is_superuser()
 end
 
 function win32.export_cmd(var, val)
-   return ("SET %s=%s"):format(var, val)
+   return ("SET %s"):format(fs.Q(var.."="..val))
 end
 
 function win32.system_cache_dir()


### PR DESCRIPTION
This should force us to test our compatibility with paths with spaces all over.

See #1618.