### PR TITLE
configure: minor version check for Lua 5.4.7-rc3 onwards

### DIFF
--- a/configure
+++ b/configure
@@ -438,6 +438,8 @@ check_incdir() {
    do
       if [ -f "$lua_h" ]
       then
+         lua_minor=$(echo "$LUA_VERSION" | cut -b 3-)
+         grep "LUA_VERSION_MINOR_N.*$lua_minor" "$lua_h" > /dev/null 2> /dev/null && return
          grep "LUA_VERSION_NUM.*$LUA_VERSION" "$lua_h" > /dev/null 2> /dev/null && return
       fi
       tried="$tried $lua_h"

--- a/src/luarocks/deps.lua
+++ b/src/luarocks/deps.lua
@@ -703,6 +703,9 @@ local function lua_h_exists(d, luaver)
       if data:match("LUA_VERSION_NUM%s*" .. tostring(luanum)) then
          return d
       end
+      if data:match("LUA_VERSION_MINOR_N%s*" .. tostring(minor)) then
+         return d
+      end
       return nil, "Lua header lua.h found at " .. d .. " does not match Lua version " .. luaver .. ". You can use `luarocks config variables.LUA_INCDIR <path>` to set the correct location.", "dependency", 2
    end
 


### PR DESCRIPTION
The previous check served us well for many years, for both Lua and LuaJIT.

A more correct solution would use the C preprocessor to read the value as suggested by @CDSoft, but the change in this commit is the simplest possible check to adapt for the new versions, while not requiring the C toolchain to be present at installation time.

Fixes #1685.