### PR TITLE
fix: use luarocks.lock in cwd for non-binary rocks too

### DIFF
--- a/src/luarocks/cmd/build.lua
+++ b/src/luarocks/cmd/build.lua
@@ -5,6 +5,7 @@ local cmd_build = {}
 
 local pack = require("luarocks.pack")
 local path = require("luarocks.path")
+local dir = require("luarocks.dir")
 local util = require("luarocks.util")
 local fetch = require("luarocks.fetch")
 local fs = require("luarocks.fs")
@@ -52,6 +53,8 @@ local function build_rock(rock_filename, opts)
    assert(type(rock_filename) == "string")
    assert(opts:type() == "build.opts")
 
+   local cwd = fs.absolute_name(dir.path("."))
+
    local ok, err, errcode
 
    local unpack_dir
@@ -71,7 +74,7 @@ local function build_rock(rock_filename, opts)
       return nil, err, errcode
    end
 
-   ok, err, errcode = build.build_rockspec(rockspec, opts)
+   ok, err, errcode = build.build_rockspec(rockspec, opts, cwd)
 
    fs.pop_dir()
    return ok, err, errcode
@@ -103,11 +106,12 @@ local function do_build(name, namespace, version, opts)
    end
 
    if url:match("%.rockspec$") then
+      local cwd = fs.absolute_name(dir.path("."))
       local rockspec, err = fetch.load_rockspec(url, nil, opts.verify)
       if not rockspec then
          return nil, err
       end
-      return build.build_rockspec(rockspec, opts)
+      return build.build_rockspec(rockspec, opts, cwd)
    end
 
    if url:match("%.src%.rock$") then

--- a/src/luarocks/cmd/install.lua
+++ b/src/luarocks/cmd/install.lua
@@ -177,7 +177,10 @@ function install.install_binary_rock_deps(rock_file, opts)
       return nil, "Failed loading rockspec for installed package: "..err, errcode
    end
 
-   ok, err, errcode = deps.fulfill_dependencies(rockspec, "dependencies", opts.deps_mode, opts.verify, install_dir)
+   local deplock_dir = fs.exists(dir.path(".", "luarocks.lock"))
+                        and "."
+                        or install_dir
+   ok, err, errcode = deps.fulfill_dependencies(rockspec, "dependencies", opts.deps_mode, opts.verify, deplock_dir)
    if err then return nil, err, errcode end
 
    util.printout()

--- a/src/luarocks/cmd/make.lua
+++ b/src/luarocks/cmd/make.lua
@@ -13,6 +13,8 @@ local pack = require("luarocks.pack")
 local remove = require("luarocks.remove")
 local deps = require("luarocks.deps")
 local writer = require("luarocks.manif.writer")
+local dir = require("luarocks.dir")
+local fs = require("luarocks.fs")
 
 function make.cmd_options(parser)
    parser:flag("--no-install", "Do not install the rock.")
@@ -88,6 +90,7 @@ function make.command(args)
       return nil, "Invalid argument: 'make' takes a rockspec as a parameter. "..util.see_help("make")
    end
 
+   local cwd = fs.absolute_name(dir.path("."))
    local rockspec, err, errcode = fetch.load_rockspec(rockspec_filename)
    if not rockspec then
       return nil, err
@@ -115,17 +118,17 @@ function make.command(args)
    end
 
    if args.no_install then
-      return build.build_rockspec(rockspec, opts)
+      return build.build_rockspec(rockspec, opts, cwd)
    elseif args.pack_binary_rock then
       return pack.pack_binary_rock(name, namespace, rockspec.version, args.sign, function()
-         local name, version = build.build_rockspec(rockspec, opts)  -- luacheck: ignore 431
+         local name, version = build.build_rockspec(rockspec, opts, cwd)  -- luacheck: ignore 431
          if name and args.no_doc then
             util.remove_doc_dir(name, version)
          end
          return name, version
       end)
    else
-      local ok, err = build.build_rockspec(rockspec, opts)
+      local ok, err = build.build_rockspec(rockspec, opts, cwd)
       if not ok then return nil, err end
       local name, version = ok, err  -- luacheck: ignore 421
 


### PR DESCRIPTION
This completes the fix for #1692.

See [this comment on the issue](https://github.com/luarocks/luarocks/issues/1662#issuecomment-2212547760).