### PR TITLE
fix: Fix upload command to include the src.rock file as a second parameter

### DIFF
--- a/src/luarocks/cmd/upload.lua
+++ b/src/luarocks/cmd/upload.lua
@@ -31,7 +31,7 @@ function upload.add_to_parser(parser)
    summary("Upload a rockspec to the public rocks repository.")
 
    cmd:argument("rockspec", "Rockspec for the rock to upload.")
-   cmd:argument("src-rock", "A corresponding .src.rock file; if not given it will be generated."):
+   cmd:argument("src_rock", "A corresponding .src.rock file; if not given it will be generated."):
    args("?")
 
    cmd:flag("--skip-pack", "Do not pack and send source rock.")

--- a/src/luarocks/cmd/upload.tl
+++ b/src/luarocks/cmd/upload.tl
@@ -31,7 +31,7 @@ function upload.add_to_parser(parser: Parser)
       :summary("Upload a rockspec to the public rocks repository.")
 
    cmd:argument("rockspec", "Rockspec for the rock to upload.")
-   cmd:argument("src-rock", "A corresponding .src.rock file; if not given it will be generated.")
+   cmd:argument("src_rock", "A corresponding .src.rock file; if not given it will be generated.")
       :args("?")
 
    cmd:flag("--skip-pack", "Do not pack and send source rock.")


### PR DESCRIPTION
Uploading pre-packaged .src.rock files was added in #1321 . But the argument name does not match the later check, if the argument is set ( https://github.com/luarocks/luarocks/pull/1321/files#diff-2f6598a403010ef65e8eeab6c8aaf74963d2cb516c8f6e79294da1d00d52d25cR78 ).
Before the fix, the src.rock was always created.

Reproduce the issue:
```bash
$ luarocks upload test-0.1.0-1.rockspec test-0.1.0-1.src.rock
Sending test-0.1.0-1.rockspec ...
Will create new module (test)
Packing test
Cloning into 'test'...
```

- [ ] Please also make sure to update the wiki page with this updated  version of the upload command.