### PR TITLE
feat: Also publish json `source_digest` field

### DIFF
--- a/publishrelease
+++ b/publishrelease
@@ -43,6 +43,10 @@ do
    }
 done
 
+source_digest="$(
+   sha256sum "luarocks-${v}.tar.gz" | cut -d' ' -f1
+)"
+
 #######################################
 # utility
 #######################################
@@ -120,7 +124,8 @@ gawk '
       print "\"'$v'\": {"
       print "\"date\": \"'$(date +'%Y-%m-%d')'\","
       print "\"files\": [\"luarocks-'$v'.tar.gz\", \"luarocks-'$v'.tar.gz.asc\", \"luarocks-'$v'-win32.zip\", \"luarocks-'$v'-win32.zip.asc\", \"luarocks-'$v'-windows-32.zip\", \"luarocks-'$v'-windows-32.zip.asc\", \"luarocks-'$v'-windows-64.zip\", \"luarocks-'$v'-windows-64.zip.asc\", \"luarocks-'$v'-linux-x86_64.zip\", \"luarocks-'$v'-linux-x86_64.zip.asc\"],"
-      print "\"about\": []"
+      print "\"about\": []",
+      print "\"source_digest\": \"'$source_digest'\""
       print "}},"
    }
 }


### PR DESCRIPTION
This PR causes the `publishrelease` script to generate, then publish a sha256 digest of the source code artifact for each release (alongside the existing json fields).

~~Drafting while I prepare the changes to add digests for all previous releases.~~

See also: https://github.com/luarocks/luarocks/pull/1741