### PR TITLE
Fix LUA_LIBDIR for msvc installations

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -343,8 +343,10 @@ local function look_for_link_libraries(directory)
 	local directories
 	if vars.LUA_LIBDIR then
 		directories = {vars.LUA_LIBDIR}
-	else
+	else if vars.SYSTEM == "mingw" then
 		directories = {directory, directory .. "\\bin", directory .. "\\lib"}
+	else
+		directories = {directory, directory .. "\\lib", directory .. "\\bin"}
 	end
 
 	for _, dir in ipairs(directories) do

--- a/install.bat
+++ b/install.bat
@@ -343,7 +343,7 @@ local function look_for_link_libraries(directory)
 	local directories
 	if vars.LUA_LIBDIR then
 		directories = {vars.LUA_LIBDIR}
-	else if vars.SYSTEM == "mingw" then
+	elseif vars.SYSTEM == "mingw" then
 		directories = {directory, directory .. "\\bin", directory .. "\\lib"}
 	else
 		directories = {directory, directory .. "\\lib", directory .. "\\bin"}

--- a/install.bat
+++ b/install.bat
@@ -343,7 +343,7 @@ local function look_for_link_libraries(directory)
 	local directories
 	if vars.LUA_LIBDIR then
 		directories = {vars.LUA_LIBDIR}
-	elseif vars.SYSTEM == "mingw" then
+	elseif USE_MINGW then
 		directories = {directory, directory .. "\\bin", directory .. "\\lib"}
 	else
 		directories = {directory, directory .. "\\lib", directory .. "\\bin"}


### PR DESCRIPTION
The order here was swapped in #1701 to fix mingw builds (see #1700), but this broke MSVC installations which need to link against the `.lib`, which defines the dll imports.