### PR TITLE
Fix make check for msys2 mingw system

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -748,7 +748,7 @@ local find_gcc_suite = function()
     for i, name in ipairs({"make", "ar", "windres", "ranlib"}) do
         result[name] = find_file(name..".exe", path)
         if not result[name] then
-            result[name] = find_file("*"..name.."*.exe", path)
+            result[name] = find_file("*-"..name.."*.exe", path)
         end
     end
 


### PR DESCRIPTION
On an msys2 install of mingw, make is installed as `mingw32-make`.

If `cmake` is installed, that takes priority over `mingw32-make` when matching the pattern `*make*.exe`.

This patch changes the pattern to be `*-make*.exe` instead to avoid this bug.