### PR TITLE
Fix lua version variable issue #719

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,6 +2,29 @@ MAKEFLAGS += --jobs=1
 
 -include config.unix
 
+#Lua version detection
+
+ifeq ($(origin LUA_VERSION),undefined)
+  # Get Lua version directly from the LUA interpreter 
+  ifneq ($(origin LUA),undefined)
+    LUA_VERSION := $(shell $(LUA) -e "print((_VERSION or ''):match('Lua (%d+%.%d+)') or '')")
+  else
+    
+	# system lua if LUA isn't defined
+    LUA_VERSION := $(shell lua -e "print((_VERSION or ''):match('Lua (%d+%.%d+)') or '')")
+  endif
+  
+  # warning if we couldn't detect the version
+  ifeq ($(LUA_VERSION),)
+    $(warning Could not automatically detect Lua version. Please set LUA_VERSION manually.)
+    
+	LUA_VERSION := 5.1
+  endif
+endif
+
+
+
+
 datarootdir = $(prefix)/share
 bindir = $(prefix)/bin
 INSTALL = install
@@ -185,3 +208,14 @@ clean: windows-clean
 		./lua_modules
 
 .PHONY: all build install install-config binary install-binary bootstrap clean windows-binary windows-clean
+
+
+
+test-lua-version:
+	@echo "Detected LUA_VERSION: $(LUA_VERSION)"
+	@echo "LUA variable: $(if $(LUA),$(LUA),(not set))"
+	@if [ -n "$(LUA)" ]; then \
+		$(LUA) -v; \
+	else \
+		lua -v; \
+	fi

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,23 +4,23 @@ MAKEFLAGS += --jobs=1
 
 #Lua version detection
 
-# ifeq ($(origin LUA_VERSION),undefined)
-#   # Get Lua version directly from the LUA interpreter 
-#   ifneq ($(origin LUA),undefined)
-#     LUA_VERSION := $(shell $(LUA) -e "print((_VERSION or ''):match('Lua (%d+%.%d+)') or '')")
-#   else
+ifeq ($(origin LUA_VERSION),undefined)
+  # Get Lua version directly from the LUA interpreter 
+  ifneq ($(origin LUA),undefined)
+    LUA_VERSION := $(shell $(LUA) -e "print((_VERSION or ''):match('Lua (%d+%.%d+)') or '')")
+  else
     
-# 	# system lua if LUA isn't defined
-#     LUA_VERSION := $(shell lua -e "print((_VERSION or ''):match('Lua (%d+%.%d+)') or '')")
-#   endif
+	# system lua if LUA isn't defined
+    LUA_VERSION := $(shell lua -e "print((_VERSION or ''):match('Lua (%d+%.%d+)') or '')")
+  endif
   
-#   # warning ifcouldn't detect the version
-#   ifeq ($(LUA_VERSION),)
-#     $(warning Could not automatically detect Lua version. Please set LUA_VERSION manually.)
+  # warning ifcouldn't detect the version
+  ifeq ($(LUA_VERSION),)
+    $(warning Could not automatically detect Lua version. Please set LUA_VERSION manually.)
     
-# 	LUA_VERSION := 5.1
-#   endif
-# endif
+	LUA_VERSION := 5.1
+  endif
+endif
 
 
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,23 +4,23 @@ MAKEFLAGS += --jobs=1
 
 #Lua version detection
 
-ifeq ($(origin LUA_VERSION),undefined)
-  # Get Lua version directly from the LUA interpreter 
-  ifneq ($(origin LUA),undefined)
-    LUA_VERSION := $(shell $(LUA) -e "print((_VERSION or ''):match('Lua (%d+%.%d+)') or '')")
-  else
+# ifeq ($(origin LUA_VERSION),undefined)
+#   # Get Lua version directly from the LUA interpreter 
+#   ifneq ($(origin LUA),undefined)
+#     LUA_VERSION := $(shell $(LUA) -e "print((_VERSION or ''):match('Lua (%d+%.%d+)') or '')")
+#   else
     
-	# system lua if LUA isn't defined
-    LUA_VERSION := $(shell lua -e "print((_VERSION or ''):match('Lua (%d+%.%d+)') or '')")
-  endif
+# 	# system lua if LUA isn't defined
+#     LUA_VERSION := $(shell lua -e "print((_VERSION or ''):match('Lua (%d+%.%d+)') or '')")
+#   endif
   
-  # warning ifcouldn't detect the version
-  ifeq ($(LUA_VERSION),)
-    $(warning Could not automatically detect Lua version. Please set LUA_VERSION manually.)
+#   # warning ifcouldn't detect the version
+#   ifeq ($(LUA_VERSION),)
+#     $(warning Could not automatically detect Lua version. Please set LUA_VERSION manually.)
     
-	LUA_VERSION := 5.1
-  endif
-endif
+# 	LUA_VERSION := 5.1
+#   endif
+# endif
 
 
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,7 +14,7 @@ ifeq ($(origin LUA_VERSION),undefined)
     LUA_VERSION := $(shell lua -e "print((_VERSION or ''):match('Lua (%d+%.%d+)') or '')")
   endif
   
-  # warning if we couldn't detect the version
+  # warning ifcouldn't detect the version
   ifeq ($(LUA_VERSION),)
     $(warning Could not automatically detect Lua version. Please set LUA_VERSION manually.)
     
@@ -209,13 +209,3 @@ clean: windows-clean
 
 .PHONY: all build install install-config binary install-binary bootstrap clean windows-binary windows-clean
 
-
-
-test-lua-version:
-	@echo "Detected LUA_VERSION: $(LUA_VERSION)"
-	@echo "LUA variable: $(if $(LUA),$(LUA),(not set))"
-	@if [ -n "$(LUA)" ]; then \
-		$(LUA) -v; \
-	else \
-		lua -v; \
-	fi


### PR DESCRIPTION
Fix: Add automatic Lua version detection to Makefile (#719)

- Implemented logic to detect Lua version dynamically using the LUA interpreter.
- Fallback added to system-wide `lua` binary if `LUA` is undefined.
- Default Lua version set to 5.1 if detection fails, with a warning message.
- Ensured compatibility with existing `config.unix` structure.

This resolves issue #719 by exposing the `LUA_VERSION` variable for Makefile use, improving flexibility for environments with multiple Lua versions.
![Screenshot From 2025-02-20 21-13-32](https://github.com/user-attachments/assets/acfaccb3-8b47-4fe1-bff4-56e0415b9209)
![Screenshot From 2025-02-20 21-13-48](https://github.com/user-attachments/assets/2dfbb4c2-60f1-45b7-a65a-ec54a2f56400)
