### PR TITLE
Fix calling lua executable sometimes not working correctly on windows

### DIFF
--- a/spec/util/test_env.lua
+++ b/spec/util/test_env.lua
@@ -297,7 +297,7 @@ local function execute_bool(command, print_command, env_variables)
       redirect = " > " .. redirect_filename
       os.remove(redirect_filename)
    end
-   local ok = test_env.execute(command .. redirect)
+   local ok = test_env.execute(command)
    if redirect ~= "" then
       if not ok or test_env.VERBOSE then
          local fd = io.open(redirect_filename, "r")

--- a/src/luarocks/util.lua
+++ b/src/luarocks/util.lua
@@ -412,9 +412,6 @@ end
 
 do
    local function Q(pathname)
-      if pathname:match("^.:") then
-         return pathname:sub(1, 2) .. '"' .. pathname:sub(3) .. '"'
-      end
       return '"' .. pathname .. '"'
    end
 

--- a/src/luarocks/util.tl
+++ b/src/luarocks/util.tl
@@ -412,9 +412,6 @@ end
 
 do
    local function Q(pathname: string): string
-      if pathname:match("^.:") then
-         return pathname:sub(1, 2) .. '"' .. pathname:sub(3) .. '"'
-      end
       return '"' .. pathname .. '"'
    end
 


### PR DESCRIPTION
Closes #1725 .

Previous behavior: executes
```
C:"Users/quadr/scoop/shims/luajit.exe"

```
New behavior: executes
```
"C:/Users/quadr/scoop/shims/luajit.exe"

```