### PR TITLE
fix: override default C compiler to cc.exe on MSYS2

### DIFF
--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -468,6 +468,12 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
       end
    end
 
+   if platforms.msys2_mingw_w64 then
+      defaults.variables.PWD = "cd"
+      defaults.variables.CC = os.getenv("CC") or "cc"
+      defaults.variables.LD = os.getenv("CC") or "cc"
+   end
+
    if platforms.bsd then
       defaults.variables.MAKE = "gmake"
       defaults.gcc_rpath = false


### PR DESCRIPTION
## Description

Fixes [https://github.com/luarocks/luarocks/issues/1753](https://github.com/luarocks/luarocks/issues/1753)

Changes: 

1. on each MSYS2 MinGW-w64 environment, there is a ```cc.exe``` that points to the default C compiler for the environment. 
2. the line

```lua
defaults.variables.PWD = "cd"
```

is meant to follow a MSYS2 patch [https://github.com/msys2/MINGW-packages/blob/5fd4997c2508f0949366513f0a2dd4347f9c4e77/mingw-w64-lua-luarocks/0001-luarocks_msys2_mingw_w64.patch#L48](https://github.com/msys2/MINGW-packages/blob/5fd4997c2508f0949366513f0a2dd4347f9c4e77/mingw-w64-lua-luarocks/0001-luarocks_msys2_mingw_w64.patch#L48) that fixes previous issues for them.

> [!NOTE]
> 
> I have opened a PR on MSYS2 [https://github.com/msys2/MINGW-packages/pull/23494](https://github.com/msys2/MINGW-packages/pull/23494) that fixes this issue. However, I guess that MSYS2 maintainers expect these changes to be first accepted  upstream.