### PR TITLE
fix: allow LuaFileSystem and LuaSocket to be properly uninstalled on MSYS2

### DIFF
--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -807,11 +807,13 @@ function cfg.init(detected, warning)
 
    local defaults = make_defaults(cfg.lua_version, processor, platforms, cfg.home)
 
-   if platforms.windows and hardcoded.WIN_TOOLS then
+   if platforms.windows and not platforms.msys2_mingw_w64 and hardcoded.WIN_TOOLS then
       local tools = { "SEVENZ", "CP", "FIND", "LS", "MD5SUM", "WGET", }
       for _, tool in ipairs(tools) do
          defaults.variables[tool] = '"' .. dir.path(hardcoded.WIN_TOOLS, defaults.variables[tool] .. '.exe') .. '"'
       end
+   elseif platforms.msys2_mingw_w64 then
+      defaults.fs_use_modules = false
    else
       defaults.fs_use_modules = true
    end


### PR DESCRIPTION
## Description

Fixes [https://github.com/luarocks/luarocks/issues/1755](https://github.com/luarocks/luarocks/issues/1755)

Changes: 

1. the idea applied as a fix was mirrored from the changes of [https://github.com/luarocks/luarocks/pull/1616](https://github.com/luarocks/luarocks/pull/1616), by setting

```lua
defaults.fs_use_modules = false
```

in a suitable place for MSYS2.

2. the line

```lua
if platforms.windows and not platforms.msys2_mingw_w64 and hardcoded.WIN_TOOLS then
```

is meant to follow a MSYS2 patch [https://github.com/msys2/MINGW-packages/blob/343eeab4f185847981c6b644d775ee98717b6231/mingw-w64-lua-luarocks/0001-luarocks_msys2_mingw_w64.patch#L57](https://github.com/msys2/MINGW-packages/blob/343eeab4f185847981c6b644d775ee98717b6231/mingw-w64-lua-luarocks/0001-luarocks_msys2_mingw_w64.patch#L57) that fixes previous issues for them.

> [!NOTE]
> 
> I tested exhaustively the behavior of LuaRocks 3.11.1 locally with / without the fix provided here on MSYS2. Ignoring minor changes due code differences between 3.9.2 and 3.11.1, my PR on MSYS2 [https://github.com/msys2/MINGW-packages/pull/23494](https://github.com/msys2/MINGW-packages/pull/23494) fixes this issue for 3.9.2.
> 
> The changes provided here sets a straightforward way to upgrade LuaRocks from 3.9.2 to 3.11.1 on MSYS2, and get rid of such issues there.