### PR TITLE
ci(unix): fix code coverage upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         luaVersion: ${{ matrix.lua-version }}
 
-    - uses: leafo/gh-actions-luarocks@v4.0.0
+    - uses: leafo/gh-actions-luarocks@v5
 
     - name: 'Setup macOS deps'
       if: ${{ contains(matrix.os, 'macos') }}
@@ -64,24 +64,31 @@ jobs:
 
     - name: Unit Test
       run: |
-        eval $(luarocks path)
         busted -o htest --exclude-tags=git,integration --verbose -Xhelper "lua_dir=$(luarocks config variables.LUA_DIR),ci"
         busted -o htest --exclude-tags=git,integration --verbose -Xhelper "lua_dir=$(luarocks config variables.LUA_DIR),ci,env=full"
 
     - name: Integration Test
       run: |
-        eval $(luarocks path)
         busted -o htest --exclude-tags=ssh,gpg,git,unit,quick --verbose -Xhelper "lua_dir=$(luarocks config variables.LUA_DIR),ci"
         busted -o htest --exclude-tags=ssh,gpg,git,unit,quick --verbose -Xhelper "lua_dir=$(luarocks config variables.LUA_DIR),ci,env=full"
+    
+    - name: Generate Coverage Report
+      working-directory: testrun
+      run: luacov -c luacov.config
 
-    - name: Coverage
-      run: |
-        eval $(luarocks path)
-        luacov -c testrun/luacov.config
-        curl -Os https://uploader.codecov.io/latest/$([ `uname -s` = "Linux" ] && echo "linux" || echo "macos")/codecov
-        chmod +x codecov
-        ( cd testrun/ && ../codecov )
-        grep "Summary" -B1 -A1000 testrun/luacov.report.out
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    
+    - name: Install Codecov
+      run: pip install codecov
+
+    - name: Upload Coverage Report
+      working-directory: testrun
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      run: codecov -t "$CODECOV_TOKEN" -f "luacov.report.out" -X gcov
 
   ##############################################################################
   SmokeTest:


### PR DESCRIPTION
## Description

In the Unix CI, the jobs are not uploading code coverage (see [https://github.com/luarocks/luarocks/actions/runs/13755355638/job/38461816117#step:10:98](https://github.com/luarocks/luarocks/actions/runs/13755355638/job/38461816117#step:10:98)), most likely due the lack of the ```CODECOV_TOKEN```:

![Screenshot from 2025-03-10 08-18-54](https://github.com/user-attachments/assets/938e1b3f-476b-49a6-81fc-0160388dbbdd)

## Changes

* Updated leafo's action to v5;
* leafo's v5 action automatically sets ```LUA_PATH```, ```LUA_CPATH``` and ```PATH``` environment variables, so I removed the statements ```eval $(luarocks path)``` in the tests;
* Mirrored the code seen on the Windows CI to perform code coverage upload.