### PR TITLE
fix(coverage): report must be generated and uploaded from the checkout dir

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,24 +71,22 @@ jobs:
       run: |
         busted -o htest --exclude-tags=ssh,gpg,git,unit,quick --verbose -Xhelper "lua_dir=$(luarocks config variables.LUA_DIR),ci"
         busted -o htest --exclude-tags=ssh,gpg,git,unit,quick --verbose -Xhelper "lua_dir=$(luarocks config variables.LUA_DIR),ci,env=full"
-    
+
     - name: Generate Coverage Report
-      working-directory: testrun
-      run: luacov -c luacov.config
+      run: luacov -c "testrun/luacov.config"
 
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
-    
+
     - name: Install Codecov
       run: pip install codecov
 
     - name: Upload Coverage Report
-      working-directory: testrun
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      run: codecov -t "$CODECOV_TOKEN" -f "luacov.report.out" -X gcov
+      run: codecov -t "$CODECOV_TOKEN" -f "testrun/luacov.report.out" -X gcov
 
   ##############################################################################
   SmokeTest:
@@ -662,14 +660,12 @@ jobs:
             ${{ matrix.FILES }}
 
       - name: Generate coverage report
-        working-directory: testrun
-        run: luacov -c "luacov.config"
+        run: luacov -c "testrun/luacov.config"
 
       - name: Install Codecov
         run: pip install codecov
 
       - name: Upload coverage report
-        working-directory: testrun
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: codecov -t "%CODECOV_TOKEN%" -f "luacov.report.out" -X gcov
+        run: codecov -t "%CODECOV_TOKEN%" -f "testrun/luacov.report.out" -X gcov

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A package manager for Lua modules.
 
 [![Build Status](https://github.com/luarocks/luarocks/actions/workflows/test.yml/badge.svg)](https://github.com/luarocks/luarocks/actions)
-[![Coverage Status](https://codecov.io/gh/luarocks/luarocks/coverage.svg?branch=main)](https://codecov.io/gh/luarocks/luarocks/branch/main)
+[![Coverage Status](https://codecov.io/gh/luarocks/luarocks/branch/main/graph/badge.svg)](https://app.codecov.io/gh/luarocks/luarocks/tree/main)
 [![Join the chat at https://gitter.im/luarocks/luarocks](https://badges.gitter.im/luarocks/luarocks.svg)](https://gitter.im/luarocks/luarocks)
 
 Main website: [luarocks.org](https://luarocks.org)


### PR DESCRIPTION
> [!NOTE]
> 
> Sorry for the many PRs that I opened recently regarding CI. I hope this is the last one.

## Description

On CI, the coverage report must be generated and uploaded from the LuaRocks checkout directory, otherwise coverage tools (luacov and codecov) will not work properly due path changes.

This issue can be seen browsing the Codecov link for the latest commit ([https://app.codecov.io/github/luarocks/luarocks/commit/e8f1267ee3d091145b281b86548a31c89ad27d74](https://app.codecov.io/github/luarocks/luarocks/commit/e8f1267ee3d091145b281b86548a31c89ad27d74)):

---

![file-path-issues](https://github.com/user-attachments/assets/912d7ba2-f0d6-4e42-839a-142d315366d9)

---

However, patching only this condition is not enough, because the badge on README would be seen as unknown:

![unknown-badge](https://github.com/user-attachments/assets/97ea5223-c9f2-4b52-a8f8-99806d02d6a4)

## Result

After applying the changes here, we get the desired output below

![resulting-badge-after-changes](https://github.com/user-attachments/assets/c33c5031-3d09-4c60-832d-9936fa420f88)

> [!TIP]
> 
> If you are interested to play with, I left the main branch on my fork [https://github.com/luau-project/luarocks](https://github.com/luau-project/luarocks) with the desired result.