### PR TITLE
ci(windows): change zlib download url

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -332,7 +332,7 @@ jobs:
         if: ${{ matrix.COMPILER == 'vs' && steps.restore-zlib-tarball.outputs.cache-hit != 'true' }}
         run: |
           curl -o "${{ github.workspace }}\zlib-${{ env.LUAROCKS_DEPS_ZLIB_VER }}.tar.gz" ^
-              "https://zlib.net/zlib-${{ env.LUAROCKS_DEPS_ZLIB_VER }}.tar.gz"
+              "https://zlib.net/fossils/zlib-${{ env.LUAROCKS_DEPS_ZLIB_VER }}.tar.gz"
 
       - name: Save zlib tarball
         if: ${{ matrix.COMPILER == 'vs' && steps.restore-zlib-tarball.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
## Description

On Windows, to build zlib as a test dependency, at the moment, the tarball is being downloaded from [https://zlib.net/zlib-1.3.1.tar.gz](https://zlib.net/zlib-1.3.1.tar.gz). However, the main page only holds the tarball for the latest released version (1.3.1).

If you try to download the previous released zlib version (1.3) from the main page, the requested tarball is not found:

![image](https://github.com/user-attachments/assets/076f60d2-754e-47be-91ab-9590c2e0958c)

This means that whenever a new zlib version pops up and the cached tarball expires, the step on CI to download zlib 1.3.1 will fail, because the tarball will not be there anymore.

According to zlib's website, all released versions of zlib are stored at [https://zlib.net/fossils/](https://zlib.net/fossils/).

## Changes

Replaced [https://zlib.net/](https://zlib.net/) by [https://zlib.net/fossils/](https://zlib.net/fossils/) to avoid a failed download when a new zlib is released and the cached version is expired.