### PR TITLE
fix(cygwin): external_deps_patterns and runtime_external_deps_patterns

### DIFF
--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -413,13 +413,24 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
    end
 
    if platforms.cygwin then
-      defaults.lib_extension = "so" -- can be overridden in the config file for mingw builds
+      defaults.lib_extension = "dll"
       defaults.arch = "cygwin-"..target_cpu
       defaults.cmake_generator = "Unix Makefiles"
       defaults.variables.CC = "echo -llua | xargs " .. (os.getenv("CC") or "gcc")
       defaults.variables.LD = "echo -llua | xargs " .. (os.getenv("CC") or "gcc")
       defaults.variables.LIBFLAG = "-shared"
       defaults.link_lua_explicitly = true
+      defaults.external_deps_patterns = {
+         bin = { "?.exe", "?.bat", "?" },
+         lib = { "cyg?.dll", "lib?.so", "lib?.so.*", "lib?.dll.a", "?.dll.a",
+                 "lib?.a", "lib?.dll", "?.dll" },
+         include = { "?.h" }
+      }
+      defaults.runtime_external_deps_patterns = {
+         bin = { "?.exe", "?.bat" },
+         lib = { "cyg?.dll", "lib?.so", "?.dll", "lib?.dll" },
+         include = { "?.h" }
+      }
    end
 
    if platforms.msys then


### PR DESCRIPTION
## Description

At the current state, `cfg.lua` does not configure LuaRocks properly to run on Cygwin, mostly because `external_deps_patterns` and `runtime_external_deps_patterns` were not defined for Cygwin. Moreover, based on the fact that most Cygwin libraries output a file `cyg*.dll` on `/bin`, I also changed `lib_extension` to be dll (it works with `so` too).

## Issue Reproduction

In order to reproduce this misconfiguration issue, I used a GitHub Workflow (in the expandable section at end) whose runs can be inspected at [https://github.com/luau-project/luarocks/actions/runs/14401670987](https://github.com/luau-project/luarocks/actions/runs/14401670987), with a job that has two working modes in the matrix: `use-patch: ['yes', 'no']`:

* when `use-patch` is `yes`, it checks out LuaRocks from the branch of this PR;
* when `use-patch` is `no`, it checks out LuaRocks from the official repository.

After installing LuaRocks on Cygwin, the workflow installs LuaFileSystem and tests it by running the official lfs script at [https://lunarmodules.github.io/luafilesystem/examples.html](https://lunarmodules.github.io/luafilesystem/examples.html) 

## Screenshots

* when `use-patch` is `yes`: 
    ![image](https://github.com/user-attachments/assets/462b92d0-1fbe-48f1-b56c-8b565ba7c921)

* when `use-patch` is `no`: 
    ![image](https://github.com/user-attachments/assets/505effc9-e355-4ce3-8a19-2fbbfff55ba5)

## Notes

I am already using a patch like this for almost half a year on all of my Lua modules to test them on Cygwin:

* `lua-cryptorandom`: [https://github.com/luau-project/lua-cryptorandom/blob/96bba484b2eac7a6ca3cb64832502a7ae0153e25/.github/workflows/ci.yml#L472](https://github.com/luau-project/lua-cryptorandom/blob/96bba484b2eac7a6ca3cb64832502a7ae0153e25/.github/workflows/ci.yml#L472)
* `lua-hash`: [https://github.com/luau-project/lua-hash/blob/ad2cfeae7a9ef4e7ccbe26cabc3658cd7e346ed2/.github/workflows/ci.yml#L474](https://github.com/luau-project/lua-hash/blob/ad2cfeae7a9ef4e7ccbe26cabc3658cd7e346ed2/.github/workflows/ci.yml#L474)
* `lua-uuid`: [https://github.com/luau-project/lua-uuid/blob/94e278e1ea733617c9a134ca83da3d8fec346517/.github/workflows/ci.yml#L630](https://github.com/luau-project/lua-uuid/blob/94e278e1ea733617c9a134ca83da3d8fec346517/.github/workflows/ci.yml#L630)
* `lua-xz`: [https://github.com/luau-project/lua-xz/blob/94dd176b3179142e282d653fd08fc608c6b9bc76/.github/workflows/ci.yml#L948](https://github.com/luau-project/lua-xz/blob/94dd176b3179142e282d653fd08fc608c6b9bc76/.github/workflows/ci.yml#L948)

## GitHub Workflow

If you want to run the GitHub workflow yourself, create a branch on your repo, paste the content yaml content on a file `.github/workflows/cygwin-issue-reproduction.yml` and push it to GitHub.

<details>
<summary>Expand here to see the GitHub workflow</summary>

```yaml
name: Cygwin Issue Reproduction

on: [push, pull_request]

jobs:
  cygwin-issue:
    runs-on: windows-latest

    defaults:
      run:
        shell: cmd

    strategy:
      fail-fast: false
      matrix:
        use-patch: ['yes', 'no']

    env:
      CYGWIN_NOWINPATH: 1
      CHERE_INVOKING: 1
      CYGWIN_INSTALL_DIR: C:\cygwin64

    steps:
      - name: Override git autocrlf to input before checkout
        run: git config --global core.autocrlf input

      - name: Checkout (from luarocks main)
        if: ${{ matrix.use-patch == 'no' }}
        uses: actions/checkout@v4
        with:
          path: luarocks
          repository: luarocks/luarocks
          ref: main

      - name: Checkout (from patch)
        if: ${{ matrix.use-patch == 'yes' }}
        uses: actions/checkout@v4
        with:
          path: luarocks
          repository: luau-project/luarocks
          ref: fix-cygwin

      - name: Setup Cygwin
        uses: cygwin/cygwin-install-action@v5
        with:
          platform: x86_64
          install-dir: ${{ env.CYGWIN_INSTALL_DIR }}
          packages: |
            coreutils,
            wget,
            gcc-g++,
            make,
            lua,
            liblua-devel,
            unzip

      - name: Check that Cygwin tools (bash and cygpath) were installed, and set environment variables to hold their paths
        run: |
          SET CYGWIN_BASH=${{ env.CYGWIN_INSTALL_DIR }}\bin\bash.exe

          IF EXIST "%CYGWIN_BASH%" (
           ECHO CYGWIN_BASH=%CYGWIN_BASH%>>${{ github.env }}
          ) ELSE (
           ECHO bash from Cygwin was not found
           EXIT /B 1
          )

          SET CYGWIN_CYGPATH=${{ env.CYGWIN_INSTALL_DIR }}\bin\cygpath.exe

          IF EXIST "%CYGWIN_CYGPATH%" (
           ECHO CYGWIN_CYGPATH=%CYGWIN_CYGPATH%>>${{ github.env }}
          ) ELSE (
           ECHO cygpath from Cygwin was not found
           EXIT /B 1
          )

      - name: Configure, build and install LuaRocks
        run: |
          FOR /F "usebackq tokens=*" %%I IN (`${{ env.CYGWIN_CYGPATH }} -u "${{ github.workspace }}\luarocks"`) DO (
            "${{ env.CYGWIN_BASH }}" -lc "cd \"%%I\" && ./configure --prefix=/usr && make \"SHEBANG=#!/usr/bin/env lua\" && make install";
            "${{ env.CYGWIN_BASH }}" -lc "echo 'eval $(luarocks path)' > /etc/profile.d/luarocks.sh";
          )

      - name: Install LuaFileSystem
        run: |
          "${{ env.CYGWIN_BASH }}" -lc "luarocks install luafilesystem"

      - name: Test LuaFileSystem
        run: |
          SET LFS_SCRIPT=local lfs = require'lfs' ^
          function attrdir (path) ^
              for file in lfs.dir(path) do ^
                  if file ~= '.' and file ~= '..' then ^
                      local f = path..'/'..file ^
                      print ('\t '..f) ^
                      local attr = lfs.attributes (f) ^
                      assert (type(attr) == 'table') ^
                      if attr.mode == 'directory' then ^
                          attrdir (f) ^
                      else ^
                          for name, value in pairs(attr) do ^
                              print (name, value) ^
                          end ^
                      end ^
                  end ^
              end ^
          end ^
          attrdir ('.')

          "${{ env.CYGWIN_BASH }}" -lc "lua -e \"%LFS_SCRIPT%\""
```

</details>