### PR TITLE
Add build variables with new rockspec format

### DIFF
--- a/docs/creating_a_makefile_that_plays_nice_with_luarocks.md
+++ b/docs/creating_a_makefile_that_plays_nice_with_luarocks.md
@@ -21,6 +21,7 @@ For building:
 * `LUA_INCDIR` - where to find the Lua headers
 * `LUALIB` - the name of the Lua library. This is not available nor needed on all platforms.
 * `LUA` - the name of the Lua interpreter
+* `LUA_VERSION` - the version of Lua
 
 For installing:
 

--- a/docs/creating_a_makefile_that_plays_nice_with_luarocks.md
+++ b/docs/creating_a_makefile_that_plays_nice_with_luarocks.md
@@ -16,18 +16,18 @@ For building:
 
 * `CFLAGS` - flags for the C compiler
 * `LIBFLAG` - the flags needed for the linker to create shared libraries
-* `LUA_LIBDIR` - where to find the lua libraries
-* `LUA_BINDIR` - where to find the lua binary
-* `LUA_INCDIR` - where to find the lua headers
-* `LUALIB` - the name of the lua library. This is not available nor needed on all platforms.
-* `LUA` - the name of the lua interpreter
+* `LUA_LIBDIR` - where to find the Lua libraries
+* `LUA_BINDIR` - where to find the Lua binary
+* `LUA_INCDIR` - where to find the Lua headers
+* `LUALIB` - the name of the Lua library. This is not available nor needed on all platforms.
+* `LUA` - the name of the Lua interpreter
 
 For installing:
 
 * `PREFIX` - basic installation prefix for the module
 * `BINDIR` - where to put user callable programs or scripts
-* `LIBDIR` - where to put the shared libraries
-* `LUADIR` - where to put the lua files
+* `LIBDIR` - where to put the shared libraries implementing modules
+* `LUADIR` - where to put the Lua scripts implementing modules
 * `CONFDIR` - where to put your modules configuration
 
 Most of these variables point immediately where you'd expect them to, but

--- a/docs/creating_a_rock.md
+++ b/docs/creating_a_rock.md
@@ -148,6 +148,14 @@ and `5.3`, but not yet-to-be-released `5.4`. There are a few other operators
 for specifying version constraints, see
 [Rockspec format](rockspec_format.md#dependency-information).
 
+Rockspecs from [`rockspec_format = "3.1"`](rockspec_format.md#package-metadata)),
+have access to special variables with the path of the installed rocks of its
+dependencies. See the [section below](#including-documentation-and-other-files)
+for information on how rocks can include files in their installation. Each
+variable is the name of the dependency followed by the suffix `_ROCKDIR`. For
+the example above, variable `LUAKNIFE_ROCKDIR` will be provided with the path of
+the installed rock.
+
 #### C modules linking to external libraries
 
 *If your code does not use third-party libraries, you may skip this subsection.*

--- a/spec/build_spec.lua
+++ b/spec/build_spec.lua
@@ -373,6 +373,52 @@ describe("LuaRocks build #integration", function()
       end)
    end)
 
+   describe("rockspec format 3.1", function()
+      it("version of Lua is not provided for old format", function()
+         test_env.run_in_tmp(function(tmpdir)
+            write_file("verify_argument.lua", string.format("assert(arg[1] == %q)", test_env.lua_version))
+            write_file("uses_luaversion_variable-3.1-11.rockspec", [[
+               package = "uses_luaversion_variable"
+               version = "3.1-11"
+               source = {
+                  url = "file://]] .. tmpdir:gsub("\\", "/") .. [[/verify_argument.lua"
+               }
+               dependencies = {
+                  "lua >= 5.1"
+               }
+               build = {
+                  type = "command",
+                  build_command = "$(LUA) verify_argument.lua $(LUA_VERSION)",
+               }
+            ]])
+            assert.is_false(run.luarocks_bool("build uses_luaversion_variable-3.1-11.rockspec"))
+         end, finally)
+      end)
+
+      it("version of Lua is provided as variable", function()
+         test_env.run_in_tmp(function(tmpdir)
+            write_file("verify_argument.lua", string.format("assert(arg[1] == %q)", test_env.lua_version))
+            write_file("uses_luaversion_variable-3.1-11.rockspec", [[
+               rockspec_format = "3.1"
+               package = "uses_luaversion_variable"
+               version = "3.1-11"
+               source = {
+                  url = "file://]] .. tmpdir:gsub("\\", "/") .. [[/verify_argument.lua"
+               }
+               dependencies = {
+                  "lua >= 5.1"
+               }
+               build = {
+                  type = "command",
+                  build_command = "$(LUA) verify_argument.lua $(LUA_VERSION)",
+               }
+            ]])
+            assert.is_truthy(run.luarocks_bool("build uses_luaversion_variable-3.1-11.rockspec"))
+            assert.is.truthy(run.luarocks("show uses_luaversion_variable"))
+         end, finally)
+      end)
+   end)
+
    describe("#mock external dependencies", function()
       lazy_setup(function()
          test_env.setup_specs(nil, "mock")

--- a/src/luarocks/deps.lua
+++ b/src/luarocks/deps.lua
@@ -329,9 +329,12 @@ function deps.fulfill_dependencies(rockspec, depskey, deps_mode, verify, deplock
       util.printout(("%s %s depends on %s (%s)"):format(
       name, version, tostring(depq), rock_status(depq, get_versions)))
 
-      local okfulfill, found_or_err, _ = deps.fulfill_dependency(depq, deps_mode, rocks_provided, verify, depskey)
+      local okfulfill, version_or_err, tree = deps.fulfill_dependency(depq, deps_mode, rocks_provided, verify, depskey)
       if okfulfill then
-         deplocks.add(depskey, depq.name, found_or_err)
+         deplocks.add(depskey, depq.name, version_or_err)
+         if tree and rockspec:format_is_at_least("3.1") then
+            rockspec.variables[depq.name:upper() .. "_ROCKDIR"] = path.install_dir(depq.name, version_or_err, tree)
+         end
       else
          if depq.constraints and depq.constraints[1] and depq.constraints[1].no_upgrade then
             util.printerr("This version of " .. name .. " is designed for use with")
@@ -341,7 +344,7 @@ function deps.fulfill_dependencies(rockspec, depskey, deps_mode, verify, deplock
             util.printerr("or look for a suitable version of " .. name .. " with")
             util.printerr("   luarocks search " .. name)
          end
-         return nil, found_or_err
+         return nil, version_or_err
       end
    end
 

--- a/src/luarocks/deps.tl
+++ b/src/luarocks/deps.tl
@@ -329,9 +329,12 @@ function deps.fulfill_dependencies(rockspec: Rockspec, depskey: DepsKey, deps_mo
       util.printout(("%s %s depends on %s (%s)"):format(
          name, version, tostring(depq), rock_status(depq, get_versions)))
 
-      local okfulfill, found_or_err, _ = deps.fulfill_dependency(depq, deps_mode, rocks_provided, verify, depskey)
+      local okfulfill, version_or_err, tree = deps.fulfill_dependency(depq, deps_mode, rocks_provided, verify, depskey)
       if okfulfill then
-         deplocks.add(depskey, depq.name, found_or_err)
+         deplocks.add(depskey, depq.name, version_or_err)
+         if tree and rockspec:format_is_at_least("3.1") then
+            rockspec.variables[depq.name:upper() .. "_ROCKDIR"] = path.install_dir(depq.name, version_or_err, tree)
+         end
       else
          if depq.constraints and depq.constraints[1] and depq.constraints[1].no_upgrade then
             util.printerr("This version of "..name.." is designed for use with")
@@ -341,7 +344,7 @@ function deps.fulfill_dependencies(rockspec: Rockspec, depskey: DepsKey, deps_mo
             util.printerr("or look for a suitable version of "..name.." with")
             util.printerr("   luarocks search "..name)
          end
-         return nil, found_or_err
+         return nil, version_or_err
       end
    end
 

--- a/src/luarocks/rockspecs.lua
+++ b/src/luarocks/rockspecs.lua
@@ -83,6 +83,9 @@ local function configure_paths(rockspec)
    vars.CONFDIR = path.conf_dir(name, version)
    vars.BINDIR = path.bin_dir(name, version)
    vars.DOCDIR = path.doc_dir(name, version)
+   if rockspec:format_is_at_least("3.1") then
+      vars.LUA_VERSION = cfg.lua_version
+   end
    rockspec.variables = vars
 end
 

--- a/src/luarocks/rockspecs.tl
+++ b/src/luarocks/rockspecs.tl
@@ -83,6 +83,9 @@ local function configure_paths(rockspec: Rockspec)
    vars.CONFDIR = path.conf_dir(name, version)
    vars.BINDIR = path.bin_dir(name, version)
    vars.DOCDIR = path.doc_dir(name, version)
+   if rockspec:format_is_at_least("3.1") then
+      vars.LUA_VERSION = cfg.lua_version
+   end
    rockspec.variables = vars
 end
 

--- a/src/luarocks/type/rockspec.lua
+++ b/src/luarocks/type/rockspec.lua
@@ -11,7 +11,7 @@ local type_check = require("luarocks.type_check")
 
 
 
-type_rockspec.rockspec_format = "3.0"
+type_rockspec.rockspec_format = "3.1"
 
 
 
@@ -174,6 +174,9 @@ local rockspec_formats, versions = type_check.declare_schemas({
          },
       },
    },
+
+   ["3.1"] = {},
+
 })
 
 

--- a/src/luarocks/type/rockspec.tl
+++ b/src/luarocks/type/rockspec.tl
@@ -11,7 +11,7 @@ local type_check = require("luarocks.type_check")
 
 -- local type TableSchema = type_check.TableSchema
 
-type_rockspec.rockspec_format = "3.0"
+type_rockspec.rockspec_format = "3.1"
 
 -- Syntax for type-checking tables:
 --
@@ -173,7 +173,10 @@ local rockspec_formats, versions = type_check.declare_schemas({
             _more = true,
          },
       }
-   }
+   },
+
+   ["3.1"] = {},
+
 })
 
 -- type_rockspec.order = {"rockspec_format", "package", "version",


### PR DESCRIPTION
This PR contains two feature commits that introduce a new rockspec format and new build variables for this new format. I can remove the second commit if the feature it adds is not desired.

The first one fixes issue [#719](https://github.com/luarocks/luarocks/issues/719) by exposing a `LUA_VERSION` variable for use by rockspec build commands, including `builtin`, `make`, and others. It follows the same approach by PR [#789](https://github.com/luarocks/luarocks/pull/789), which introduces a new rockspec format as suggested [here](https://github.com/luarocks/luarocks/pull/789#issuecomment-382099519).

The second one adds variables that expose the installed directory of the dependency rocks, so the build can access any of the dependencies' installed rocks like directories `conf` or other non-standard directories defines by `copy_directories`.

My original motivation for this support is due to library [LuaMemory](https://github.com/renatomaia/lua-memory) that exposes both a Lua module and a C API (as a C library), and the [Coutil](https://github.com/renatomaia/coutil) library that depends on this C API. I was recommended to keep the LuaMemory C API counterpart as an external dependency for both [LuaMemory rock](https://luarocks.org/manifests/maia/memory-2.0.0-1.rockspec) and [Coutil rock](https://luarocks.org/manifests/maia/coutil-2.0.0-1.rockspec), and users are required to get the LuaMemory's C library using ad-hoc approaches (make, cmake, distro packages, etc.) even though LuaRocks has all the capacity required to distribute such pure Lua libraries.

Fast-forward a couple of years, and now I found I can expose the LuaMemory's C API from its own Lua module to other modules loaded later by using `package.loadlib` (see [here](https://github.com/renatomaia/coutil/blob/ba55f2f06ebec3242a520b41db03e9ed6e3057fd/demo/console.lua#L34)). However, we still need access to its headers (and in Windows to the lib that links to the DLL) to build modules like Coutil, and ideally the headers compatible with the rock installed. Also. I tried to achieve this with current LuaRocks in the following rockspec:

```lua
local luamem_release = "2.1.0-1"

package="coutil"
version="2.0.1-1"
...
dependencies = {
	"lua == 5.4",
	"vararg >= 2.1, < 3.0",
	"memory == "..luamem_release,
}
external_dependencies = {
	LIBUV = {
		header = "uv.h",
		library = "uv",
	},
}
build = {
	type = "cmake",
	variables = {
		CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS = "ON",
		CMAKE_INSTALL_PREFIX = "$(PREFIX)",
		CMAKE_LIBRARY_PATH = "$(LUA_LIBDIR);$(ROCKS_TREE)/memory/"..luamem_release.."/library;$(LIBUV_LIBDIR)",
		LUA_INCLUDE_DIR = "$(LUA_INCDIR)",
		LUAMEM_INCLUDE_DIR = "$(ROCKS_TREE)/memory/"..luamem_release.."/include",
		LIBUV_INCLUDE_DIR = "$(LIBUV_INCDIR)",
		MODULE_DESTINATION = "$(LIBDIR)",
	},
	...
}
```

But this approach have a lot of problems like:

- The rockspec must force a specific dependency version and revision.
- I believe the `ROCKS_TREE` variable refers the location the rock being built will be installed and not necessarily where its dependencies are installed, so the path used might be inexistent or wrong.

With the proposed feature we could have:

```lua
rockspec_format = "3.1"
package="coutil"
version="2.0.1-1"
...
dependencies = {
	"lua == 5.4",
	"vararg >= 2.1, < 3.0",
	"memory >= 2.1, < 3.0",
}
external_dependencies = {
	LIBUV = {
		header = "uv.h",
		library = "uv",
	},
}
build = {
	type = "cmake",
	variables = {
		CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS = "ON",
		CMAKE_INSTALL_PREFIX = "$(PREFIX)",
		CMAKE_LIBRARY_PATH = "$(LUA_LIBDIR);$(MEMORY_ROCKDIR)/library;$(LIBUV_LIBDIR)",
		LUA_INCLUDE_DIR = "$(LUA_INCDIR)",
		LUAMEM_INCLUDE_DIR = "$(MEMORY_ROCKDIR)/include",
		LIBUV_INCLUDE_DIR = "$(LIBUV_INCDIR)",
		MODULE_DESTINATION = "$(LIBDIR)",
	},
	...
}
```
