### PR TITLE
Avoid overrwriting CMake variables from rockspec

### DIFF
--- a/src/luarocks/build/cmake.lua
+++ b/src/luarocks/build/cmake.lua
@@ -27,11 +27,6 @@ function cmake.run(rockspec, no_install)
    local build = rockspec.build
    local variables = build.variables or {}
 
-
-   variables.CMAKE_MODULE_PATH = os.getenv("CMAKE_MODULE_PATH")
-   variables.CMAKE_LIBRARY_PATH = os.getenv("CMAKE_LIBRARY_PATH")
-   variables.CMAKE_INCLUDE_PATH = os.getenv("CMAKE_INCLUDE_PATH")
-
    util.variable_substitutions(variables, rockspec.variables)
 
    local ok, err_msg = fs.is_tool_available(rockspec.variables.CMAKE, "CMake")

--- a/src/luarocks/build/cmake.tl
+++ b/src/luarocks/build/cmake.tl
@@ -27,11 +27,6 @@ function cmake.run(rockspec: Rockspec, no_install: boolean): boolean, string, st
    local build = rockspec.build as cmake.CMakeBuild
    local variables = build.variables or {}
 
-   -- Pass Env variables
-   variables.CMAKE_MODULE_PATH=os.getenv("CMAKE_MODULE_PATH")
-   variables.CMAKE_LIBRARY_PATH=os.getenv("CMAKE_LIBRARY_PATH")
-   variables.CMAKE_INCLUDE_PATH=os.getenv("CMAKE_INCLUDE_PATH")
-
    util.variable_substitutions(variables, rockspec.variables)
 
    local ok, err_msg = fs.is_tool_available(rockspec.variables.CMAKE, "CMake")


### PR DESCRIPTION
I noticed that `luarocks.build.cmake` always replace `CMAKE_LIBRARY_PATH` from the rockspec with the value from the environment variable of the same name. This way we cannot easily provide to CMake the paths provided by LuaRocks (ex `LUA_LIBDIR`, `<ext_lib>_LIBDIR`, etc.). Moreover, CMake seems to read these environment variables (see [here](https://cmake.org/cmake/help/latest/variable/CMAKE_LIBRARY_PATH.html)) anyway, so I cannot figure out why this override was even necessary in the first place. For this reason my suggestion with this PR is to simply remove this "Pass Env variables" block entirely.

Alternatively, if we actually need to pass these environment variables to CMake as CLI arguments for some reason, then at least we should do something like the following to avoid overwriting definitions from the `rockspec`:

```diff
diff --git a/src/luarocks/build/cmake.tl b/src/luarocks/build/cmake.tl
index 9a512d1e..ee793e46 100644
--- a/src/luarocks/build/cmake.tl
+++ b/src/luarocks/build/cmake.tl
@@ -28,9 +28,9 @@ function cmake.run(rockspec: Rockspec, no_install: boolean): boolean, string, st
    local variables = build.variables or {}
 
    -- Pass Env variables
-   variables.CMAKE_MODULE_PATH=os.getenv("CMAKE_MODULE_PATH")
-   variables.CMAKE_LIBRARY_PATH=os.getenv("CMAKE_LIBRARY_PATH")
-   variables.CMAKE_INCLUDE_PATH=os.getenv("CMAKE_INCLUDE_PATH")
+   variables.CMAKE_MODULE_PATH = variables.CMAKE_MODULE_PATH or os.getenv("CMAKE_MODULE_PATH")
+   variables.CMAKE_LIBRARY_PATH = variables.CMAKE_LIBRARY_PATH or os.getenv("CMAKE_LIBRARY_PATH")
+   variables.CMAKE_INCLUDE_PATH = variables.CMAKE_INCLUDE_PATH or os.getenv("CMAKE_INCLUDE_PATH")
 
    util.variable_substitutions(variables, rockspec.variables)
 
```