### PR TITLE
fix: test errors on luajit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,8 @@ jobs:
         luaVersion: ${{ matrix.lua-version }}
 
     - uses: leafo/gh-actions-luarocks@v5
+      with:
+        luaRocksVersion: "3.11.2"
 
     - name: 'Setup macOS deps'
       if: ${{ contains(matrix.os, 'macos') }}
@@ -594,11 +596,11 @@ jobs:
           SET "CURRENT_LUA_BIN=%CURRENT_LUA_DIR%\bin"
           SET "CURRENT_LUA_INTERPRETER=%CURRENT_LUA_BIN%\lua.exe"
 
-          pip install hererocks && ^
+          pip install git+https://github.com/luarocks/hererocks && ^
           hererocks ^
             "%CURRENT_LUA_DIRNAME%" ^
             "--${{ matrix.LUAT }}" "${{ matrix.LUAV }}" ^
-            --luarocks latest ^
+            --luarocks "@418d2ab34891b130cc317df32f65f978640febcf" ^
             "--target=${{ matrix.COMPILER }}"
 
           IF %ERRORLEVEL% NEQ 0 (

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,9 +45,9 @@ jobs:
       with:
         luaVersion: ${{ matrix.lua-version }}
 
-    - uses: leafo/gh-actions-luarocks@v5
+    - uses: luarocks/gh-actions-luarocks@master
       with:
-        luaRocksVersion: "3.11.2"
+        luaRocksVersion: "@418d2ab34891b130cc317df32f65f978640febcf"
 
     - name: 'Setup macOS deps'
       if: ${{ contains(matrix.os, 'macos') }}


### PR DESCRIPTION
### This PR
1. Use a new fixed version on ubuntu and macos.
According to https://github.com/luarocks/luarocks/pull/1798#issuecomment-2936292335, I need to use the version number in the update upstream leafo/gh-actions-luarocks to ensure that the new luarocks build is installed.

    I notice that https://github.com/leafo/gh-actions-luarocks/blob/4c082a5fad45388feaeb0798dbd82dbd7dc65bca/action.yml#L10-L13 So we can leave the downstream project unupdated for now. And instead, just install it using the specified version.
This parameter does not support the input of a commit id, so it seems that we need to release a version first 🤔 This requires feedback from the maintainers.

2. The tests on windows have been updated to not use hererocks from PyPi.
   Instead, we follow the README instructions and install hererocks using pip install git+url, which allows us to use the latest hererocks.

    In addition to this, the luarocks version is specified as the last commit it, so this ensures that the tests are run on the correct luarocks version.

### Some things are still pending

1. No new tags are released, so tests can't always be automatically run with the latest. We need to specify the version, which won't be retained in the project, and we'll have to change it again when a release is done.

2. Downstream projects are still not updated, such as `gh-actions-luarocks` and `hererocks`. This still seems to be waiting for a release with fixes to be completed here.

---

I'm not sure how we should handle the workflow for this one; it's a bit complicated.
If we don't release it, the test won't pass completely. This is because tests based on `gh-actions-luarocks` can't use the commit ID as a version.

There are two solutions to this:

1. The first is to first release a version of `3.11.x` patch that includes that fixed feature, which will help the test pass;
    This would leave us with having to release a version with a flaw in the test, even though we fully understand why it happened. This may break the old rules to some extent.

2. The other is to issue a PR to the downstream project `gh-actions-luarocks` to allow it to specify a @commit-id similar to hererocks as the version number.
    I'm familiar with JavaScript, and this works, but I have no control over when this can be done.
LuaJIT-based use cases have been blocked for a while now, and a good portion of them use [OpenResty](https://github.com/openresty/lua-nginx-module/) and [Apache APISIX API Gateway](https://github.com/apache/apisix) or other API gateway users.
    While it is true that there is some workaround, it can't be seen as a viable solution for the long term. I'm concerned that continued unavailability could damage LuaRocks's reputation in these use cases.
    I'm going to start this and if I can get it done quickly and get the maintainer's approval, then things will be easy. (UPDATED: https://github.com/leafo/gh-actions-luarocks/pull/26)


Would appreciate your advice on how to deal with this problem!