### PR TITLE
allow LuaJIT users to fetch json manifest when local cache directoy does not exist

### DIFF
--- a/src/luarocks/fetch.lua
+++ b/src/luarocks/fetch.lua
@@ -54,7 +54,7 @@ function fetch.fetch_caching(url, mirroring)
    local cachefile = dir.path(cache_dir, filename)
    local checkfile = cachefile .. ".check"
 
-   if (fs.file_age(checkfile) < 10 or
+   if (fs.exists(checkfile) and fs.file_age(checkfile) < 10 or
       cfg.aggressive_cache and (not name:match("^manifest"))) and fs.exists(cachefile) then
 
       return cachefile, nil, nil, true
@@ -75,6 +75,8 @@ function fetch.fetch_caching(url, mirroring)
       if not ok then
          return nil, "Failed creating temporary cache directory " .. cache_dir
       end
+      cachefile = dir.path(cache_dir, filename)
+      checkfile = cachefile .. ".check"
       lock = fs.lock_access(cache_dir)
    end
 

--- a/src/luarocks/fetch.lua
+++ b/src/luarocks/fetch.lua
@@ -49,7 +49,10 @@ function fetch.fetch_caching(url, mirroring)
    local repo_url, filename = url:match("^(.*)/([^/]+)$")
    local name = repo_url:gsub("[/:]", "_")
    local cache_dir = dir.path(cfg.local_cache, name)
-   local ok = fs.make_dir(cache_dir)
+   local ok = fs.exists(cfg.local_cache)
+   if ok then
+      ok = fs.make_dir(cache_dir)
+   end
 
    local cachefile = dir.path(cache_dir, filename)
    local checkfile = cachefile .. ".check"

--- a/src/luarocks/fetch.tl
+++ b/src/luarocks/fetch.tl
@@ -49,12 +49,15 @@ function fetch.fetch_caching(url: string, mirroring?: string): string, string, s
    local repo_url, filename = url:match("^(.*)/([^/]+)$")
    local name = repo_url:gsub("[/:]","_")
    local cache_dir = dir.path(cfg.local_cache, name)
-   local ok = fs.make_dir(cache_dir)
+   local ok = fs.exists(cfg.local_cache)
+   if ok then
+      ok = fs.make_dir(cache_dir)
+   end
 
    local cachefile = dir.path(cache_dir, filename)
    local checkfile = cachefile .. ".check"
 
-   if (fs.file_age(checkfile) < 10 or
+   if (fs.exists(checkfile) and fs.file_age(checkfile) < 10 or
       cfg.aggressive_cache and (not name:match("^manifest"))) and fs.exists(cachefile)
    then
       return cachefile, nil, nil, true
@@ -75,6 +78,8 @@ function fetch.fetch_caching(url: string, mirroring?: string): string, string, s
       if not ok then
          return nil, "Failed creating temporary cache directory "..cache_dir
       end
+      cachefile = dir.path(cache_dir, filename)
+      checkfile = cachefile .. ".check"
       lock = fs.lock_access(cache_dir)
    end
 


### PR DESCRIPTION
## Description

Fixes #1805 

## Changes

1. At the moment, employing the LuaJIT interpreter, when an user tries to install a package, LuaRocks assumes that the directory defined by `cfg.local_cache` exists (usually, this variable takes a subdirectory inside the home directory). However, on #1805, OP shown an use case such that an user may be created without a home directory. So, the first block of changes is preventing the creation of the cache directory when `cfg.local_cache` does not exist (for most users, it will exist anyway), because not doing that, LuaRocks will try to create a protected dir (`/home` is protected) and thus fail;
2. The second block of changes guards the `fs.file_age` from non-existent file;
3.  In the absence of `cfg.local_cache` directory, LuaRocks falls back to creating a temporary cache dir by calling `cfg.local_cache = fs.make_temp_dir("local_cache")` in the natural flow. When the fallback is activated to create a temporary cache dir, at the moment, `cachefile` and `checkfile` are not updated to reflect the change on `cfg.local_cache`. The third block of changes updates `cachefile` and `checkfile` variables for subsequent code accessing such variables to face up to date values.

> [!NOTE]
> 
> On #1805 , OP confirmed the changes proposed here fixed the issue