### PR TITLE
fix: deps.check_lua_libdir() should read liblua in binary mode

### DIFF
--- a/src/luarocks/deps.lua
+++ b/src/luarocks/deps.lua
@@ -811,7 +811,7 @@ function deps.check_lua_libdir(vars)
    local err
    if ok then
       local filename = dir.path(vars.LUA_LIBDIR, vars.LUA_LIBDIR_FILE)
-      local fd = io.open(filename, "r")
+      local fd = io.open(filename, "rb")
       if fd then
          if not vars.LUA_LIBDIR_FILE:match((cfg.lua_version:gsub("%.", "%%.?"))) then
 

--- a/src/luarocks/deps.tl
+++ b/src/luarocks/deps.tl
@@ -811,7 +811,7 @@ function deps.check_lua_libdir(vars: {string: string}): boolean, string, string,
    local err: string
    if ok then
       local filename = dir.path(vars.LUA_LIBDIR, vars.LUA_LIBDIR_FILE)
-      local fd = io.open(filename, "r")
+      local fd = io.open(filename, "rb")
       if fd then
          if not vars.LUA_LIBDIR_FILE:match((cfg.lua_version:gsub("%.", "%%.?"))) then
             -- if filename isn't versioned, check file contents


### PR DESCRIPTION
Hi, I stumbled over this while I was doing some cross-compilation testing using luarocks on Windows. Although luarocks is seemingly fine reading a `.dll` in text mode on Windows, an ELF-formatted `.so` not so much, which leads to reporting a Lua library mismatch error.

This PR fixes the issue.