### PR TITLE
chore(ci): bump OpenSSL to 3.5.1 on Windows and minor edits.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -304,7 +304,7 @@ jobs:
       # The following env variables
       # only applies to Visual Studio
       LUAROCKS_DEPS_DIR: c:\external
-      LUAROCKS_DEPS_OPENSSL_VER: "3.4.1"
+      LUAROCKS_DEPS_OPENSSL_VER: "3.5.1"
       LUAROCKS_DEPS_ZLIB_VER: "1.3.1"
       # The following env variable
       # applies to both Visual Studio and MinGW-w64
@@ -487,7 +487,7 @@ jobs:
           }
 
           if ($installerUrl -eq $null) {
-            throw "Installer not found for version $version";
+            throw "Installer not found for version ${version}. Please, update OpenSSL to the latest version found at ${jsonUrl}";
           }
 
           # Download the installer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
 
     - uses: luarocks/gh-actions-luarocks@master
       with:
-        luaRocksVersion: "@418d2ab34891b130cc317df32f65f978640febcf"
+        luaRocksVersion: "3.12.2"
 
     - name: 'Setup macOS deps'
       if: ${{ contains(matrix.os, 'macos') }}
@@ -601,7 +601,7 @@ jobs:
           hererocks ^
             "%CURRENT_LUA_DIRNAME%" ^
             "--${{ matrix.LUAT }}" "${{ matrix.LUAV }}" ^
-            --luarocks "@418d2ab34891b130cc317df32f65f978640febcf" ^
+            --luarocks "3.12.2" ^
             "--target=${{ matrix.COMPILER }}"
 
           IF %ERRORLEVEL% NEQ 0 (

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,17 +2,18 @@ name: test
 
 on:
   push:
-    branches: main
+    branches:
+      - main
     paths-ignore:
       - "docs"
       - "**/*.md"
   pull_request:
-    branches: '*'
+    branches:
+      - '*'
     paths-ignore:
       - "docs"
       - "**/*.md"
   workflow_dispatch:
-    branches: '*'
 
 jobs:
   ##############################################################################


### PR DESCRIPTION
## Description

As the title says: bump OpenSSL to 3.5.1 on Windows, and other minor edits.

## Changes

1. Fix `yaml` lint issues related to GitHub Actions schema;

<img width="1534" height="498" alt="yaml-lint-issues" src="https://github.com/user-attachments/assets/b824288e-8318-43cc-8577-dc6ef9a249ee" />

2. Bump OpenSSL version to 3.5.1 and improve the error message when the current version was not found;

> [!NOTE]
> 
> The current 3.4.1 is not available anymore (see [https://raw.githubusercontent.com/slproweb/opensslhashes/master/win32_openssl_hashes.json](https://raw.githubusercontent.com/slproweb/opensslhashes/master/win32_openssl_hashes.json)). Thus, it is causing PRs to fail on Windows (see [https://github.com/luarocks/luarocks/pull/1814](https://github.com/luarocks/luarocks/pull/1814)).

3. Use a LuaRocks's release version (3.12.2) that addressed the LuaJIT 65535 constraint issue. The current version on CI (a safe commit `@418d2ab34891b130cc317df32f65f978640febcf`) was included as a work around (see [https://github.com/luarocks/luarocks/commit/7b9ccdc7ff9587bfdf5efbe0e7dd0f3b66a0e84d](https://github.com/luarocks/luarocks/commit/7b9ccdc7ff9587bfdf5efbe0e7dd0f3b66a0e84d) and [https://github.com/luarocks/luarocks/commit/7c3a2ec75e970a701ed0aa0728998270d73b40aa](https://github.com/luarocks/luarocks/commit/7c3a2ec75e970a701ed0aa0728998270d73b40aa)) to bypass the LuaJIT limitation.