### PR TITLE
ci: GitHub Actions zizmor remove persist-credentials

### DIFF
--- a/.github/workflows/pr-gh-actions.yml
+++ b/.github/workflows/pr-gh-actions.yml
@@ -56,7 +56,7 @@ jobs:
           repository: ${{ env.TARGET_REPOSITORY }}
           token: ${{ secrets.GH_ACTIONS_LUAROCKS_TOKEN }}
           path: gh-actions-luarocks
-          persist-credentials: false
+          persist-credentials: true  # Needed for git push.
 
       - name: Create a new branch
         working-directory: gh-actions-luarocks

--- a/.github/workflows/pr-gh-actions.yml
+++ b/.github/workflows/pr-gh-actions.yml
@@ -56,6 +56,7 @@ jobs:
           repository: ${{ env.TARGET_REPOSITORY }}
           token: ${{ secrets.GH_ACTIONS_LUAROCKS_TOKEN }}
           path: gh-actions-luarocks
+          persist-credentials: false
 
       - name: Create a new branch
         working-directory: gh-actions-luarocks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Prep
       run: |
@@ -41,6 +43,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - uses: luarocks/gh-actions-lua@fc6f8de246f8c01f6e1a56a1b851143e23370ff3 # v12
       with:
@@ -96,6 +100,8 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - uses: luarocks/gh-actions-lua@fc6f8de246f8c01f6e1a56a1b851143e23370ff3 # v12
       with:
@@ -112,6 +118,8 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - uses: luarocks/gh-actions-lua@fc6f8de246f8c01f6e1a56a1b851143e23370ff3 # v12
       with:
@@ -143,6 +151,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     # [!NOTE]:
     #
@@ -257,6 +267,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup MSVC dev prompt
         if: ${{ matrix.COMPILER == 'vs' }}


### PR DESCRIPTION
[zizmor](https://docs.zizmor.sh) is a static analysis tool that can find and fix security issues in common CI/CD setups, including GitHub Actions, Dependabot, and pre-commit.

This PR fixes https://docs.zizmor.sh/audits/#artipacked

Zizmor finds other issues, but let's leave those for a separate pull request.  Careful review of `pr-gh-actions.yml` please, because it performs git operations that may require `persist-credentials` ~but I think not~.