### PR TITLE
improve failure message to help user

### DIFF
--- a/src/luarocks/deps.tl
+++ b/src/luarocks/deps.tl
@@ -241,7 +241,7 @@ function deps.fulfill_dependency(dep: Query, deps_mode: string, rocks_provided: 
 
    found, where = match_dep(dep, get_versions)
    if not found then
-       return nil, "Repository inconsistency detected (previously unfinished/corrupted installation?)"
+       return nil, "Repository inconsistency detected for dependency"..dep.name.." (previously unfinished/corrupted installation?)"
    end
    return true, found, where
 end

--- a/src/luarocks/deps.tl
+++ b/src/luarocks/deps.tl
@@ -241,7 +241,7 @@ function deps.fulfill_dependency(dep: Query, deps_mode: string, rocks_provided: 
 
    found, where = match_dep(dep, get_versions)
    if not found then
-       return nil, "Repository inconsistency detected for dependency"..dep.name.." (previously unfinished/corrupted installation?)"
+       return nil, "Repository inconsistency detected for dependency "..dep.name.." (previously unfinished/corrupted installation?)"
    end
    return true, found, where
 end


### PR DESCRIPTION
I was trying to run `:Rocks install rocks.nvim` from neovim, which results in:
```
luarocks "--force-lock" "--lua-version=5.1" "--tree=/home/teto/.local/share/nvim/rocks" "--server='https://luarocks.org/manifests/neorocks/'" "--server='https://lumen-oss.github.io/rocks-binaries/'" "install" "--force" "rocks.nvim"`
Installing https://luarocks.org/rocks.nvim-2.49.0-1.src.rock

Missing dependencies for rocks.nvim 2.49.0-1:
   nvim-nio (not installed)
   rtp.nvim (not installed)

rocks.nvim 2.49.0-1 depends on lua 5.1 (5.1-1 provided by VM: success)
rocks.nvim 2.49.0-1 depends on luarocks >= 3.11.1, < 4.0.0 (3.13.0-1 installed: success)
rocks.nvim 2.49.0-1 depends on toml-edit >= 0.6.1 (0.7.0-1 installed: success)
rocks.nvim 2.49.0-1 depends on fidget.nvim >= 1.1.0 (1.6.0-1 installed: success)
rocks.nvim 2.49.0-1 depends on fzy (1.0.3-1 installed: success)
rocks.nvim 2.49.0-1 depends on nvim-nio (not installed)
Installing https://luarocks.org/nvim-nio-1.10.1-1.src.rock
nvim-nio 1.10.1-1 is already installed in /home/teto/.local/share/nvim/rocks
Use --force to reinstall.

Error: Repository inconsistency detected (previously unfinished/corrupted installation?)
```

The error spaws from luarocks 3.13 so the root problem of the dependency not being detected might already have been solved in newer releases. 
Problem is rocks.nvim only displayed the last bit (maybe because of stderr vs stdout distinction ?), patching the error message to display which dep causes the problem is still helpful.